### PR TITLE
Add end-to-end workflow test and fix issues

### DIFF
--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -81,7 +81,7 @@ class Notify(Resource):
 
 
 @assembly_ns.expect(new_project_model)
-@dart_ns.route('/new_project')
+@assembly_ns.route('/new_project')
 class NewProject(Resource):
     @api.doc(False)
     def options(self):
@@ -95,7 +95,7 @@ class NewProject(Resource):
 
 
 @assembly_ns.expect(project_records_model)
-@dart_ns.route('/add_project_records')
+@assembly_ns.route('/add_project_records')
 class AddProjectRecords(Resource):
     @api.doc(False)
     def options(self):

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -4,6 +4,7 @@ from flask_restx import Api, Resource, fields
 from .controller import ServiceController
 
 db_url = get_config('INDRA_WM_SERVICE_DB', failure_ok=False)
+local_storage = get_config('INDRA_WM_CACHE')
 sc = ServiceController(db_url)
 
 
@@ -76,7 +77,7 @@ class Notify(Resource):
         record = {k: request.json[k] for k in ['identity', 'version',
                                                'document_id', 'storage_key']}
         sc.add_dart_record(record)
-        sc.process_dart_record(record)
+        sc.process_dart_record(record, local_storage=local_storage)
         return 'OK'
 
 

--- a/indra_world/service/corpus_manager.py
+++ b/indra_world/service/corpus_manager.py
@@ -12,12 +12,14 @@ logger = logging.getLogger(__name__)
 
 
 class CorpusManager:
-    def __init__(self, db_url, dart_records, corpus_id, metadata):
+    def __init__(self, db_url, dart_records, corpus_id, metadata,
+                 local_storage=None):
         self.sc = ServiceController(db_url=db_url)
         self.corpus_id = corpus_id
         self.dart_records = dart_records
         self.metadata = metadata
         self.assembled_stmts = None
+        self.local_storage = local_storage
 
     def prepare(self):
         self.sc.db.add_corpus(self.corpus_id, self.metadata)
@@ -27,9 +29,10 @@ class CorpusManager:
         )
         for record in self.dart_records:
             # This adds DART records
-            self.sc.add_dart_record(**record)
+            self.sc.add_dart_record(record)
             # This adds prepared statements
-            self.sc.process_dart_record(**record)
+            self.sc.process_dart_record(record,
+                                        local_storage=self.local_storage)
 
     def assemble(self):
         all_stmts = []

--- a/indra_world/service/db/schema.py
+++ b/indra_world/service/db/schema.py
@@ -59,6 +59,6 @@ class Corpora(Base):
 
 class CorpusRecords(Base):
     __tablename__ = 'corpus_records'
-    _dummy = Column(String, primary_key=True)
+    _dummy = Column(Integer, primary_key=True)
     corpus_id = Column(String)
     record_key = Column(String)

--- a/indra_world/service/db/schema.py
+++ b/indra_world/service/db/schema.py
@@ -12,7 +12,7 @@ class Projects(Base):
 
 
 class ProjectRecords(Base):
-    __tablename__ = 'project_documents'
+    __tablename__ = 'project_records'
     _dummy = Column(Integer, primary_key=True)
     project_id = Column(String)
     record_key = Column(String)
@@ -58,7 +58,7 @@ class Corpora(Base):
 
 
 class CorpusRecords(Base):
-    __tablename__ = 'corpus_documents'
+    __tablename__ = 'corpus_records'
     _dummy = Column(String, primary_key=True)
     corpus_id = Column(String)
     record_key = Column(String)

--- a/indra_world/tests/test_workflow.py
+++ b/indra_world/tests/test_workflow.py
@@ -1,0 +1,69 @@
+import os
+import glob
+import uuid
+import random
+from indra_world.service.app import sc
+from indra_world.service.db.manager import DbManager
+from indra_world.service.corpus_manager import CorpusManager
+from .test_rest_api import _call_api
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEST_DB_FILE = os.path.join(HERE, 'workflow_test.db')
+TEST_DB_URL = f'sqlite:///{TEST_DB_FILE}'
+
+
+def test_end_to_end():
+    try:
+        os.remove(TEST_DB_FILE)
+    except FileNotFoundError:
+        pass
+    sc.db = DbManager(url=TEST_DB_URL)
+    sc.db.create_all()
+
+    # Populate the records here
+    dart_base = os.path.join(os.path.expanduser('~'), 'data', 'dart')
+    print(f'Dart base: {dart_base}')
+    readers = ['eidos', 'sofia', 'hume']
+    versions = ['1.1.0', '1.2_compositional',
+                'r2021_03_15.7ddc68e6.compositional.r1']
+    all_records = []
+    for reader, version in zip(readers, versions):
+        fnames = glob.glob(os.path.join(dart_base, reader, version, '*'))
+        doc_ids = [os.path.basename(fname) for fname in fnames]
+        # These are totally synthetic, they have to be unique but are otherwise
+        # arbitrary when using local storage for DART
+        storage_keys = [str(uuid.uuid4()) for _ in doc_ids]
+        records = [{'identity': reader,
+                    'version': version,
+                    'storage_key': storage_key,
+                    'document_id': doc_id}
+                   for storage_key, doc_id in zip(storage_keys, doc_ids)]
+        all_records += records
+    # Choose a random sample for an initial corpus
+    random.seed(123)
+    random.shuffle(all_records)
+    LIMIT = 10
+    corpus_records = all_records[:LIMIT]
+    cm = CorpusManager(db_url=TEST_DB_URL,
+                       dart_records=corpus_records,
+                       corpus_id='test_corpus',
+                       metadata={},
+                       local_storage=dart_base)
+    cm.prepare()
+    os.environ['INDRA_WM_CACHE'] = dart_base
+    res = _call_api('post', 'assembly/new_project',
+                    json={'project_id': 'test_project',
+                          'project_name': 'my project',
+                          'corpus_id': 'test_corpus'})
+    res = _call_api('post', 'dart/notify',
+                    json=all_records[LIMIT])
+    assert res == 'OK'
+    res = _call_api('post', 'assembly/add_project_records',
+                    json={'project_id': 'test_project',
+                          'records': [all_records[LIMIT]]})
+    assert set(res) == {'new_stmts', 'new_evidence', 'new_refinements',
+                        'beliefs'}
+    assert len(res['new_stmts']) == 7, len(res['new_stmts'])
+    assert len(res['new_evidence']) == 7
+    assert len(res['new_refinements']) == 2
+    assert len(res['beliefs']) == 307

--- a/indra_world/tests/test_workflow.py
+++ b/indra_world/tests/test_workflow.py
@@ -2,6 +2,7 @@ import os
 import glob
 import uuid
 import random
+from nose.plugins.attrib import attr
 from indra_world.service.app import sc
 from indra_world.service.db.manager import DbManager
 from indra_world.service.corpus_manager import CorpusManager
@@ -12,6 +13,7 @@ TEST_DB_FILE = os.path.join(HERE, 'workflow_test.db')
 TEST_DB_URL = f'sqlite:///{TEST_DB_FILE}'
 
 
+@attr('notravis')
 def test_end_to_end():
     try:
         os.remove(TEST_DB_FILE)


### PR DESCRIPTION
This PR adds an end-to-end workflow tests which consists of (1) assembling a new corpus "offline" from a set of reader outputs and then using the web service to (2) start a new project from the given corpus, (3) receive a notification about a new reader output and (4) receive a request to add the new record to the new project and return an assembly delta. The PR also fixes issues found along the way.