### PR TITLE
Implement more service endpoints

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,4 @@ services:
     entrypoint: gunicorn -w 1 -b :8000 -t 600 indra_world.service.app:app
   db:
     image: postgres:indra_world
-    ports:
-      - "5434:5432"
     env_file: indra_world_db.env

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -36,6 +36,11 @@ dart_record_model = api.model(
     }
 )
 
+project_model = api.model(
+    'Project',
+    {'project_id': fields.String(example='project1', required=True)}
+)
+
 project_records_model = api.model(
     'ProjectRecords',
     {'project_id': fields.String(example='project1'),
@@ -43,12 +48,11 @@ project_records_model = api.model(
      }
 )
 
-
 new_project_model = api.model(
     'NewProject',
-    {'project_id': fields.String(example='project1'),
-     'project_name': fields.String(example='Project 1'),
-     'corpus_id': fields.String(example='corpus1')
+    {'project_id': fields.String(example='project1', required=True),
+     'project_name': fields.String(example='Project 1', required=True),
+     'corpus_id': fields.String(example='corpus1', required=False)
      }
 )
 
@@ -128,6 +132,20 @@ class GetProjects(Resource):
     def get(self):
         projects = sc.get_projects()
         return projects
+
+
+@assembly_ns.expect(project_model)
+@assembly_ns.route('/get_project_records')
+class GetProjectRecords(Resource):
+    @api.doc(False)
+    def options(self):
+        return {}
+
+    def get(self):
+        project_id = request.json.get('project_id')
+        records = sc.get_project_records(project_id)
+        return records
+
 
 # download_curations
 # submit_curations

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -59,10 +59,17 @@ curation_model = api.model(
     }
 )
 
+curation_model_wrapped = api.model(
+    'CurationWrapped',
+    {
+        '12345': fields.Nested(curation_model)
+    }
+)
+
 submit_curations_model = api.model(
     'SubmitCurations',
     {'project_id': fields.String(example='project1'),
-     'curations': fields.List(fields.Nested(curation_model))
+     'curations': fields.List(fields.Nested(curation_model_wrapped))
      }
 )
 
@@ -182,6 +189,7 @@ class SubmitCurations(Resource):
             sc.add_curation(project_id, curation)
 
 
+@assembly_ns.expect(project_model)
 @assembly_ns.route('/get_project_curations')
 class GetProjectCurations(Resource):
     @api.doc(False)

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -119,6 +119,16 @@ class AddProjectRecords(Resource):
         return delta.to_json()
 
 
+@assembly_ns.route('/get_projects')
+class GetProjects(Resource):
+    @api.doc(False)
+    def options(self):
+        return {}
+
+    def get(self):
+        projects = sc.get_projects()
+        return projects
+
 # download_curations
 # submit_curations
 

--- a/indra_world/service/controller.py
+++ b/indra_world/service/controller.py
@@ -44,6 +44,9 @@ class ServiceController:
     def unload_project(self, project_id):
         self.assemblers.pop(project_id, None)
 
+    def get_projects(self):
+        return self.db.get_projects()
+
     def add_dart_record(self, record, date=None):
         if date is None:
             date = datetime.datetime.utcnow().isoformat()

--- a/indra_world/service/controller.py
+++ b/indra_world/service/controller.py
@@ -47,6 +47,9 @@ class ServiceController:
     def get_projects(self):
         return self.db.get_projects()
 
+    def get_project_records(self, project_id):
+        return self.db.get_records_for_project(project_id)
+
     def add_dart_record(self, record, date=None):
         if date is None:
             date = datetime.datetime.utcnow().isoformat()

--- a/indra_world/service/controller.py
+++ b/indra_world/service/controller.py
@@ -108,5 +108,8 @@ class ServiceController:
     def add_curation(self, project_id, curation):
         return self.db.add_curation_for_project(project_id, curation)
 
+    def get_project_curations(self, project_id):
+        return self.db.get_curations_for_project(project_id)
+
     def add_project_records(self, project_id, record_keys):
         return self.db.add_records_for_project(project_id, record_keys)

--- a/indra_world/service/db/manager.py
+++ b/indra_world/service/db/manager.py
@@ -91,6 +91,11 @@ class DbManager:
         doc_ids = sorted(set(r[0] for r in q.all()))
         return doc_ids
 
+    def get_projects(self):
+        q = self.query(wms_schema.Projects)
+        projects = [{'id': p.id, 'name': p.name} for p in q.all()]
+        return projects
+
     def add_corpus(self, corpus_id, metadata):
         op = insert(wms_schema.Corpora).values(id=corpus_id,
                                                meta_data=metadata)

--- a/indra_world/tests/test_db_manager.py
+++ b/indra_world/tests/test_db_manager.py
@@ -78,3 +78,15 @@ def test_add_no_stmts_for_record():
                                  indra_version='1.0')
     stmts = db.get_statements()
     assert len(stmts) == 2
+
+
+def test_get_projects():
+    db = _get_db()
+    projects = db.get_projects()
+    assert not projects
+    db.add_project('p1', 'Project 1')
+    db.add_project('p2', 'Project 2')
+    projects = db.get_projects()
+    assert len(projects) == 2
+    assert {p['id'] for p in projects} == {'p1', 'p2'}
+    assert {p['name'] for p in projects} == {'Project 1', 'Project 2'}

--- a/indra_world/tests/test_rest_api.py
+++ b/indra_world/tests/test_rest_api.py
@@ -83,3 +83,15 @@ def test_notify_duplicate(mock_get):
                         document_id=doc_id,
                         storage_key=storage_key
                     ))
+
+
+def test_get_projects():
+    sc.db = DbManager(url='sqlite:///:memory:')
+    sc.db.create_all()
+    _call_api('post', 'assembly/new_project',
+              json=dict(
+                  project_id='p1',
+                  project_name='Project 1'
+              ))
+    res = _call_api('get', 'assembly/get_projects', json={})
+    assert res

--- a/indra_world/tests/test_rest_api.py
+++ b/indra_world/tests/test_rest_api.py
@@ -95,3 +95,30 @@ def test_get_projects():
               ))
     res = _call_api('get', 'assembly/get_projects', json={})
     assert res
+
+
+@patch('indra_world.sources.dart.client.get_content_by_storage_key')
+def test_get_project_records(mock_get):
+    mock_get.return_value = _get_eidos_output()
+    sc.db = DbManager(url='sqlite:///:memory:')
+    sc.db.create_all()
+    _call_api('post', 'assembly/new_project',
+              json=dict(
+                  project_id='p1',
+                  project_name='Project 1'
+              ))
+    doc_id = '70a62e43-f881-47b1-8367-a3cca9450c03'
+    storage_key = 'bcd04c45-3cfc-456f-a31e-59e875aefabf.json'
+    record = {'identity': 'eidos',
+              'version': '1.0',
+              'document_id': doc_id,
+              'storage_key': storage_key}
+    res = _call_api('post', 'dart/notify', json=record)
+    res = _call_api('post', 'assembly/add_project_records',
+                    json=dict(
+                        project_id='p1',
+                        records=[record]
+                    ))
+    res = _call_api('get', 'assembly/get_project_records',
+                    json=dict(project_id='p1'))
+    assert res == [storage_key]

--- a/indra_world/tests/test_rest_api.py
+++ b/indra_world/tests/test_rest_api.py
@@ -122,3 +122,26 @@ def test_get_project_records(mock_get):
     res = _call_api('get', 'assembly/get_project_records',
                     json=dict(project_id='p1'))
     assert res == [storage_key]
+
+
+def test_curations():
+    sc.db = DbManager(url='sqlite:///:memory:')
+    sc.db.create_all()
+
+    _call_api('post', 'assembly/new_project',
+              json=dict(
+                  project_id='p1',
+                  project_name='Project 1'
+              ))
+    curation = {'project_id': 'p1',
+                'statement_id': '12345',
+                'update_type': 'discard_statement'}
+    _call_api('post', 'assembly/submit_curations',
+              json=dict(
+                  project_id='p1',
+                  curations={'12345': curation}
+              ))
+    res = _call_api('get', 'assembly/get_project_curations',
+                    json=dict(project_id='p1'))
+    assert len(res) == 1
+    assert res[0] == curation

--- a/indra_world/tests/test_service_controller.py
+++ b/indra_world/tests/test_service_controller.py
@@ -122,3 +122,11 @@ def test_duplicate_record():
     assert res.get('rowcount') == 1
     res = sc.add_dart_record(rec, '2020')
     assert res is None
+
+
+def test_get_projects():
+    sc = _get_controller()
+    sc.new_project('p1', 'Project 1')
+    projects = sc.get_projects()
+    assert len(projects) == 1
+    assert projects[0] == {'id': 'p1', 'name': 'Project 1'}


### PR DESCRIPTION
This PR adds new service endpoints as follows:
- `get_projects`: List current projects
- `get_project_records`: List records associated with a given project
- `submit_curations`: Submit a list of curations for a project
- `get_project_curations`: Get curations associated with a given project