### PR TITLE
Refactor DART client as a class

### DIFF
--- a/indra_world/dashboard/app.py
+++ b/indra_world/dashboard/app.py
@@ -9,11 +9,12 @@ from wtforms.fields.html5 import DateField
 from flask_bootstrap import Bootstrap
 
 from indra.config import get_config
-import indra_world.sources.dart.client as dart_client
+from indra_world.sources.dart import DartClient, prioritize_records
 from indra_world.service.corpus_manager import CorpusManager
 
 
 DB_URL = get_config('INDRA_WM_SERVICE_DB', failure_ok=False)
+dart_client = DartClient()
 
 
 logger = logging.getLogger('indra_wm_service.assembly_dashboard')
@@ -83,7 +84,7 @@ def run_assembly():
     if not records:
         return jsonify({})
 
-    records = dart_client.prioritize_records(records, reader_priorities)
+    records = prioritize_records(records, reader_priorities)
 
     num_docs = len({rec['document_id'] for rec in records})
 

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -2,9 +2,14 @@ from indra.config import get_config
 from flask import Flask, request, abort
 from flask_restx import Api, Resource, fields
 from .controller import ServiceController
+from ..sources.dart import DartClient
+
 
 db_url = get_config('INDRA_WM_SERVICE_DB', failure_ok=False)
-local_storage = get_config('INDRA_WM_CACHE')
+if not get_config('DART_WM_URL'):
+    dart_client = DartClient(storage_mode='local')
+else:
+    dart_client = DartClient(storage_mode='web')
 sc = ServiceController(db_url)
 
 
@@ -109,7 +114,7 @@ class Notify(Resource):
         if res is None:
             abort(400, 'The record could not be added, possibly because '
                        'it\'s a duplicate.')
-        sc.process_dart_record(record, local_storage=local_storage)
+        sc.process_dart_record(record)
         return 'OK'
 
 

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -10,7 +10,7 @@ if not get_config('DART_WM_URL'):
     dart_client = DartClient(storage_mode='local')
 else:
     dart_client = DartClient(storage_mode='web')
-sc = ServiceController(db_url)
+sc = ServiceController(db_url, dart_client=dart_client)
 
 
 app = Flask(__name__)

--- a/indra_world/service/controller.py
+++ b/indra_world/service/controller.py
@@ -16,20 +16,14 @@ expected_readers = {'eidos', 'hume', 'sofia'}
 
 
 class ServiceController:
-    def __init__(self, db_url, dart_url=None, local_storage=None):
+    def __init__(self, db_url, dart_client=None):
         self.db = DbManager(db_url)
         self.assemblers = {}
         self.assembly_triggers = {}
-        if not dart_url and not local_storage:
-            self.dart_client = DartClient(storage_mode='web',
-                                          local_storage=local_storage)
-        elif dart_url:
-            self.dart_client = DartClient(storage_mode='web',
-                                          dart_url=dart_url,
-                                          local_storage=local_storage)
+        if dart_client:
+            self.dart_client = dart_client
         else:
-            self.dart_client = DartClient(storage_mode='local',
-                                          local_storage=local_storage)
+            self.dart_client = DartClient(storage_mode='web')
 
     def new_project(self, project_id, name, corpus_id=None):
         res = self.db.add_project(project_id, name)

--- a/indra_world/service/corpus_manager.py
+++ b/indra_world/service/corpus_manager.py
@@ -13,13 +13,14 @@ logger = logging.getLogger(__name__)
 
 class CorpusManager:
     def __init__(self, db_url, dart_records, corpus_id, metadata,
-                 local_storage=None):
-        self.sc = ServiceController(db_url=db_url)
+                 dart_url=None, local_storage=None):
+        self.sc = ServiceController(db_url=db_url,
+                                    dart_url=dart_url,
+                                    local_storage=local_storage)
         self.corpus_id = corpus_id
         self.dart_records = dart_records
         self.metadata = metadata
         self.assembled_stmts = None
-        self.local_storage = local_storage
 
     def prepare(self):
         self.sc.db.add_corpus(self.corpus_id, self.metadata)
@@ -31,8 +32,7 @@ class CorpusManager:
             # This adds DART records
             self.sc.add_dart_record(record)
             # This adds prepared statements
-            self.sc.process_dart_record(record,
-                                        local_storage=self.local_storage)
+            self.sc.process_dart_record(record)
 
     def assemble(self):
         all_stmts = []

--- a/indra_world/service/corpus_manager.py
+++ b/indra_world/service/corpus_manager.py
@@ -13,10 +13,8 @@ logger = logging.getLogger(__name__)
 
 class CorpusManager:
     def __init__(self, db_url, dart_records, corpus_id, metadata,
-                 dart_url=None, local_storage=None):
-        self.sc = ServiceController(db_url=db_url,
-                                    dart_url=dart_url,
-                                    local_storage=local_storage)
+                 dart_client=None):
+        self.sc = ServiceController(db_url=db_url, dart_client=dart_client)
         self.corpus_id = corpus_id
         self.dart_records = dart_records
         self.metadata = metadata

--- a/indra_world/service/db/manager.py
+++ b/indra_world/service/db/manager.py
@@ -15,6 +15,7 @@ class DbManager:
     for various operations."""
     def __init__(self, url):
         self.url = make_url(url)
+        logger.info('Starting DB manager with URL: %s' % self.url)
         self.engine = create_engine(self.url)
         self.session = None
 

--- a/indra_world/service/db/manager.py
+++ b/indra_world/service/db/manager.py
@@ -15,7 +15,7 @@ class DbManager:
     for various operations."""
     def __init__(self, url):
         self.url = make_url(url)
-        logger.info('Starting DB manager with URL: %s' % self.url)
+        logger.info('Starting DB manager with URL: %s' % str(self.url))
         self.engine = create_engine(self.url)
         self.session = None
 

--- a/indra_world/sources/dart/client.py
+++ b/indra_world/sources/dart/client.py
@@ -23,7 +23,8 @@ class DartClient:
     def __init__(self, storage_mode='web', dart_url=None, dart_uname=None,
                  dart_pwd=None, local_storage=None):
         self.storage_mode = storage_mode
-        self.local_storage = local_storage
+        self.local_storage = local_storage if local_storage else \
+            get_config('INDRA_WM_CACHE')
         if self.storage_mode == 'web':
             if dart_url:
                 self.dart_url = dart_url

--- a/indra_world/sources/dart/client.py
+++ b/indra_world/sources/dart/client.py
@@ -90,6 +90,8 @@ class DartClient:
             except Exception as e:
                 logger.error('Could not create DART client local storage: %s'
                              % e)
+        logger.info('Running DART client in %s mode with local storage at %s' %
+                    (self.storage_mode, self.local_storage))
 
     def get_outputs_from_records(self, records):
         """Return reader outputs corresponding to a list of records.

--- a/indra_world/sources/dart/client.py
+++ b/indra_world/sources/dart/client.py
@@ -83,7 +83,7 @@ class DartClient:
 
     def get_output_from_record(self, record):
         storage_key = record['storage_key']
-        fname = self.get_local_storage_path(self.local_storage, record)
+        fname = self.get_local_storage_path(record)
         output = None
         if os.path.exists(fname):
             with open(fname, 'r') as fh:
@@ -94,6 +94,7 @@ class DartClient:
             except Exception as e:
                 logger.warning('Error downloading %s: %s' %
                                (storage_key, e))
+                return None
             try:
                 if self.local_storage:
                     with open(fname, 'w') as fh:
@@ -200,7 +201,7 @@ class DartClient:
                         version_paths = glob.glob(path)
                         for version_path in version_paths:
                             version = os.path.basename(version_path)
-                            path  = glob.glob(version_path, '*')
+                            path = glob.glob(version_path, '*')
                             for file in glob.glob(path):
                                 doc_id = os.path.basename(file)
                                 record = {

--- a/indra_world/tests/test_dart_client.py
+++ b/indra_world/tests/test_dart_client.py
@@ -84,8 +84,7 @@ def test_prioritize():
 
 @attr('nonpublic', 'notravis')
 def test_api():
-    health_ep = dart_client.dart_base_url + '/health'
-    dart_uname = get_config('DART_WM_USERNAME', failure_ok=False)
-    dart_pwd = get_config('DART_WM_PASSWORD', failure_ok=False)
-    res = requests.get(health_ep, auth=(dart_uname, dart_pwd))
+    client = dart_client.DartClient()
+    url = client.dart_url + '/health'
+    res = requests.get(url, auth=(client.dart_uname, client.dart_pwd))
     assert res.status_code == 200

--- a/indra_world/tests/test_rest_api.py
+++ b/indra_world/tests/test_rest_api.py
@@ -42,7 +42,6 @@ def test_notify():
     sc.db.create_all()
     _orig = sc.dart_client.get_output_from_record
     sc.dart_client.get_output_from_record = lambda x: _get_eidos_output()
-    sc.dart_client.get_output_from_record = _orig
 
     # Call the service, which will send a request to the server.
     doc_id = '70a62e43-f881-47b1-8367-a3cca9450c03'
@@ -63,6 +62,7 @@ def test_notify():
 
     stmts = sc.db.get_statements_for_document(document_id=doc_id)
     assert len(stmts) == 1, stmts
+    sc.dart_client.get_output_from_record = _orig
 
 
 @raises(ValueError)
@@ -71,7 +71,6 @@ def test_notify_duplicate():
     sc.db.create_all()
     _orig = sc.dart_client.get_output_from_record
     sc.dart_client.get_output_from_record = lambda x: _get_eidos_output()
-    sc.dart_client.get_output_from_record = _orig
 
     # Call the service, which will send a request to the server.
     doc_id = '70a62e43-f881-47b1-8367-a3cca9450c03'
@@ -91,6 +90,7 @@ def test_notify_duplicate():
                         document_id=doc_id,
                         storage_key=storage_key
                     ))
+    sc.dart_client.get_output_from_record = _orig
 
 
 def test_get_projects():
@@ -110,7 +110,6 @@ def test_get_project_records():
     sc.db.create_all()
     _orig = sc.dart_client.get_output_from_record
     sc.dart_client.get_output_from_record = lambda x: _get_eidos_output()
-    sc.dart_client.get_output_from_record = _orig
     _call_api('post', 'assembly/new_project',
               json=dict(
                   project_id='p1',
@@ -131,6 +130,7 @@ def test_get_project_records():
     res = _call_api('get', 'assembly/get_project_records',
                     json=dict(project_id='p1'))
     assert res == [storage_key]
+    sc.dart_client.get_output_from_record = _orig
 
 
 def test_curations():

--- a/indra_world/tests/test_service_controller.py
+++ b/indra_world/tests/test_service_controller.py
@@ -1,18 +1,24 @@
 import os
 from copy import deepcopy
 from .test_incremental_assembler import s1, s2
+from indra_world.sources.dart import DartClient
 from indra_world.service.controller import ServiceController
+
+HERE = os.path.dirname(os.path.abspath(__file__))
 
 
 def _get_eidos_output():
-    fname = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                         'eidos_compositional.jsonld')
+    fname = os.path.join(HERE, 'eidos_compositional.jsonld')
     with open(fname, 'r') as fh:
         return fh.read()
 
 
 def _get_controller():
-    sc = ServiceController(db_url='sqlite:///:memory:')
+    local_storage = os.path.join(HERE, 'dart')
+    dart_client = DartClient(storage_mode='local',
+                             local_storage=local_storage)
+    sc = ServiceController(db_url='sqlite:///:memory:',
+                           dart_client=dart_client)
     sc.db.create_all()
     return sc
 


### PR DESCRIPTION
This PR refactors the DART client to be a class, allowing multiple operation modes and storage modes. It is now possible to run the client in a fully local mode without the remote webservice being available.