### PR TITLE
Curations and post-processing in incremental assembly

### DIFF
--- a/indra_world/assembly/incremental_assembler.py
+++ b/indra_world/assembly/incremental_assembler.py
@@ -46,8 +46,10 @@ class IncrementalAssembler:
             self.refinement_filters = refinement_filters
 
         self.curations = curations if curations else []
-        self.post_processing_steps = [add_flattened_grounding_compositional,
-                                      standardize_names_compositional] \
+        self.post_processing_steps = [
+                {'function': 'add_flattened_grounding_compositional',
+                 'function': 'standardize_names_compositional'}
+            ] \
             if post_processing_steps is None else post_processing_steps
 
         self.deduplicate()

--- a/indra_world/assembly/incremental_assembler.py
+++ b/indra_world/assembly/incremental_assembler.py
@@ -93,7 +93,6 @@ class IncrementalAssembler:
                 elif role == 'obj':
                     stmt.obj.concept.db_refs['WM'][0] = (grounding, 1.0)
 
-
     def deduplicate(self):
         for stmt in self.prepared_stmts:
             stmt_hash = stmt.get_hash(matches_fun=self.matches_fun)
@@ -123,8 +122,7 @@ class IncrementalAssembler:
 
     def build_refinements_graph(self, stmts_by_hash, refinement_edges):
         g = networkx.DiGraph()
-        nodes = [(sh, {'stmt': stmt})
-                 for sh, stmt in stmts_by_hash.items()]
+        nodes = [(sh, {'stmt': stmt}) for sh, stmt in stmts_by_hash.items()]
         g.add_nodes_from(nodes)
         g.add_edges_from(refinement_edges)
         return g
@@ -179,8 +177,15 @@ class IncrementalAssembler:
     def get_beliefs(self):
         self.beliefs = {}
         for sh, evs in self.evs_by_stmt_hash.items():
-            self.beliefs[sh] = self.belief_scorer.score_evidence_list(
-                self.get_all_supporting_evidence(sh))
+            if sh in self.known_corrects:
+                self.beliefs[sh] = 1
+                # TODO: should we propagate this belief to all the less
+                # specific statements? One option is to add those statements'
+                # hashes to the known_corrects list and then at this point
+                # we won't need any special handling.
+            else:
+                self.beliefs[sh] = self.belief_scorer.score_evidence_list(
+                    self.get_all_supporting_evidence(sh))
         return self.beliefs
 
     def get_statements(self):

--- a/indra_world/assembly/incremental_assembler.py
+++ b/indra_world/assembly/incremental_assembler.py
@@ -47,8 +47,8 @@ class IncrementalAssembler:
 
         self.curations = curations if curations else []
         self.post_processing_steps = [
-                {'function': 'add_flattened_grounding_compositional',
-                 'function': 'standardize_names_compositional'}
+                {'function': 'add_flattened_grounding_compositional'},
+                {'function': 'standardize_names_compositional'},
             ] \
             if post_processing_steps is None else post_processing_steps
 

--- a/indra_world/assembly/incremental_assembler.py
+++ b/indra_world/assembly/incremental_assembler.py
@@ -30,11 +30,18 @@ class IncrementalAssembler:
     ----------
     prepared_stmts : list[indra.statements.Statement]
         A list of prepared INDRA Statements.
-    refinement_filters : list[indra.preassembler.refinement.RefinementFilter]
+    refinement_filters : Optional[list[indra.preassembler.refinement.RefinementFilter]]
         A list of refinement filter classes to be used for refinement
-        finding.
+        finding. Default: the standard set of compositional refinement filters.
+    matches_fun : Optional[function]
+        A custom matches function for determining matching statements and
+        calculating hashes. Default: matches function that takes
+        compositional grounding and location into account.
     curations : list[dict]
         A list of user curations to be integrated into the assembly results.
+    post_processing_steps : list[dict]
+        Steps that can be used in an INDRA AssemblyPipeline to do
+        post-processing on statements.
 
     Attributes
     ----------

--- a/indra_world/tests/test_incremental_assembler.py
+++ b/indra_world/tests/test_incremental_assembler.py
@@ -1,3 +1,5 @@
+import copy
+
 from indra.statements import Influence, Event, Concept, Evidence
 from indra_world.assembly.incremental_assembler import \
     IncrementalAssembler, AssemblyDelta
@@ -93,3 +95,23 @@ def test_incremental_assembler_add_statement_new_refinement():
     assert set(ia.get_all_supporting_evidence(s1h)) == {ev1, ev2, ev4}
     assert set(ia.get_all_supporting_evidence(s2h)) == {ev2, ev4}
     assert set(ia.get_all_supporting_evidence(s4h)) == {ev4}
+
+
+def test_post_processing_all_stmts():
+    stmts = copy.deepcopy([s1, s2])
+    ia = IncrementalAssembler(stmts)
+    stmts_out = ia.get_statements()
+    assert stmts_out[0].subj.concept.name == 'agriculture'
+    flat_grounding = [{'grounding': 'wm/concept/agriculture',
+                       'name': 'agriculture', 'score': 1.0}]
+    assert stmts_out[0].subj.concept.db_refs['WM_FLAT'] == \
+        flat_grounding, flat_grounding
+
+
+def test_post_processing_new_stmts():
+    stmts = copy.deepcopy([s1, s2])
+    ia = IncrementalAssembler([stmts[0]])
+    delta = ia.add_statements([stmts[1]])
+    assert len(delta.new_stmts) == 1
+    stmt = list(delta.new_stmts.values())[0]
+    assert stmt.subj.concept.name == 'crop'


### PR DESCRIPTION
This PR adds an initial implementation of handling user curations (change grounding, change polarity, change event roles, discard statement, vet statement) during runtime with the IncrementalAssembler. Curations are applied internally on de-duplicated statements but the changes to statements resulting from curations aren't surfaced/returned explicitly. Also, these operations aren't yet extensively tested - tests will need to be implemented later.

The PR also adds a configurable list of post-processing steps to the IncrementalAssembler for operations such as name normalization, and flattened grounding generation that don't affect the assembly process but are needed by downstream tools.