### PR TITLE
Fixes to assembly delta

### DIFF
--- a/indra_world/assembly/incremental_assembler.py
+++ b/indra_world/assembly/incremental_assembler.py
@@ -323,7 +323,7 @@ class AssemblyDelta:
     beliefs : dict[str, float]
         A dict of belief scores keyed by all statement hashes (both old and
         new).
-    matches_fun : Optional[function]
+    matches_fun : Optional[Callable[[Statement], str]]
         An optional custom matches function. When using a custom matches
         function for assembly, providing it here is necessary to get
         correct JSON serialization.

--- a/indra_world/assembly/incremental_assembler.py
+++ b/indra_world/assembly/incremental_assembler.py
@@ -258,7 +258,7 @@ class IncrementalAssembler:
                                      matches_fun=self.matches_fun)
         beliefs = self.get_beliefs()
         return AssemblyDelta(new_stmts, new_evidences, new_refinements,
-                             beliefs)
+                             beliefs, matches_fun=self.matches_fun)
 
     def get_all_supporting_evidence(self, sh):
         """Return direct and incirect evidence for a statement hash."""
@@ -323,17 +323,23 @@ class AssemblyDelta:
     beliefs : dict[str, float]
         A dict of belief scores keyed by all statement hashes (both old and
         new).
+    matches_fun : Optional[function]
+        An optional custom matches function. When using a custom matches
+        function for assembly, providing it here is necessary to get
+        correct JSON serialization.
     """
-    def __init__(self, new_stmts, new_evidences, new_refinements, beliefs):
+    def __init__(self, new_stmts, new_evidences, new_refinements, beliefs,
+                 matches_fun=None):
         self.new_stmts = new_stmts
         self.new_evidences = new_evidences
         self.new_refinements = new_refinements
         self.beliefs = beliefs
+        self.matches_fun = matches_fun
 
     def to_json(self):
         """Return a JSON representation of the assembly delta."""
         return {
-            'new_stmts': {sh: stmt.to_json()
+            'new_stmts': {sh: stmt.to_json(matches_fun=self.matches_fun)
                           for sh, stmt in self.new_stmts.items()},
             'new_evidence': {sh: [ev.to_json() for ev in evs]
                              for sh, evs in self.new_evidences.items()},

--- a/indra_world/assembly/incremental_assembler.py
+++ b/indra_world/assembly/incremental_assembler.py
@@ -338,9 +338,16 @@ class AssemblyDelta:
 
     def to_json(self):
         """Return a JSON representation of the assembly delta."""
+        # Serialize statements with custom matches function to make
+        # sure matches hashes are consistent
+        new_stmts_json = {sh: stmt.to_json(matches_fun=self.matches_fun)
+                          for sh, stmt in self.new_stmts.items()}
+        # Pop out evidence since it is redundant with the new_evidence field
+        for stmtj in new_stmts_json.values():
+            stmtj.pop('evidence', None)
+        # Return the full construct
         return {
-            'new_stmts': {sh: stmt.to_json(matches_fun=self.matches_fun)
-                          for sh, stmt in self.new_stmts.items()},
+            'new_stmts': new_stmts_json,
             'new_evidence': {sh: [ev.to_json() for ev in evs]
                              for sh, evs in self.new_evidences.items()},
             'new_refinements': list(self.new_refinements),

--- a/indra_world/tests/test_incremental_assembler.py
+++ b/indra_world/tests/test_incremental_assembler.py
@@ -39,6 +39,8 @@ def test_assembly_delta_construct_serialize():
                        new_refinements=new_refinements,
                        beliefs=beliefs)
     adj = ad.to_json()
+    assert 'evidence' not in adj['new_stmts'][s1h]
+    assert adj['new_evidence'][s1h]
 
 
 def test_assembly_delta_custom_matches():

--- a/indra_world/tests/test_incremental_assembler.py
+++ b/indra_world/tests/test_incremental_assembler.py
@@ -41,6 +41,25 @@ def test_assembly_delta_construct_serialize():
     adj = ad.to_json()
 
 
+def test_assembly_delta_custom_matches():
+    from indra.statements.context import WorldContext, RefContext
+    stmt = copy.deepcopy(s1)
+    stmt.subj.context = WorldContext(geo_location=RefContext('Africa'))
+    sh = stmt.get_hash(refresh=True,
+                       matches_fun=location_matches_compositional)
+    new_stmts = {sh: stmt}
+    new_evidences = {sh: stmt.evidence}
+    new_refinements = []
+    beliefs = {sh: 1.0}
+    ad = AssemblyDelta(new_stmts, new_evidences, new_refinements, beliefs)
+    adj = ad.to_json()
+    assert adj['new_stmts'][sh]['matches_hash'] != sh
+    ad = AssemblyDelta(new_stmts, new_evidences, new_refinements, beliefs,
+                       matches_fun=location_matches_compositional)
+    adj = ad.to_json()
+    assert adj['new_stmts'][sh]['matches_hash'] == sh
+
+
 def test_incremental_assembler_constructor():
     ia = IncrementalAssembler([s1, s2])
     assert ia.prepared_stmts == [s1, s2]


### PR DESCRIPTION
This PR fixes the matches hash calculation when JSON-serializing the AssemblyDelta object. It also removes the redundant evidence in the new_stmts entry of the JSON.