### PR TITLE
API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Outputs
+*.xml

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -126,6 +126,11 @@ sofia_json_model = api.model(
     })
 
 # Models for response
+health_model = api.model('Health', {
+    'state': fields.String(example='healthy'),
+    'version': fields.String(example='1.0.0')
+})
+
 project_resp_model = api.model('ProjectResponse', {
     'id': fields.String(example='project1', description='Project ID'),
     'name': fields.String(example='Project 1', description='Project name')
@@ -162,6 +167,7 @@ class Health(Resource):
     def options(self):
         return {}
 
+    @base_ns.response(200, 'State and version of the API', health_model)
     def get(self):
         return {'state': 'healthy', 'version': '1.0.0'}
 
@@ -174,6 +180,7 @@ class Notify(Resource):
     def options(self):
         return {}
 
+    @dart_ns.response(200, 'DART record is added and processed')
     def post(self):
         """Add and process DART record.
 
@@ -209,6 +216,7 @@ class NewProject(Resource):
     def options(self):
         return {}
 
+    @assembly_ns.response(200, 'New project is created')
     def post(self):
         """Create new project.
 

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -159,10 +159,30 @@ stmt_fields = fields.Raw(example={
     ],
     "sbo": "https://identifiers.org/SBO:0000526",
     "evidence": [{"text": "MEK binds ERK", "source_api": "trips"}]
-})
+}, description='INDRA Statement JSON')
 
 stmts_model = api.model('Statements', {
     'statements': fields.List(stmt_fields)
+})
+
+delta_fields = fields.Raw(example={
+    'new_statements': {
+        '12345': {
+            "id": "acc6d47c-f622-41a4-8ae9-d7b0f3d24a2f",
+            "type": "Complex",
+            "members": [
+                {"db_refs": {"TEXT": "MEK", "FPLX": "MEK"}, "name": "MEK"},
+                {"db_refs": {"TEXT": "ERK", "FPLX": "ERK"}, "name": "ERK"}
+            ],
+            "sbo": "https://identifiers.org/SBO:0000526",
+            "evidence": [{"text": "MEK binds ERK", "source_api": "trips"}]
+        }
+    },
+    'new_evidence': {
+        '12345': [{"text": "MEK binds ERK", "source_api": "trips"}]
+    },
+    'new_refinements': [['12345', '23456'], ['34567', '45678']],
+    'beliefs': {'12345': 0.7, '23456': 0.9}
 })
 
 def _stmts_from_proc(proc):
@@ -263,6 +283,7 @@ class AddProjectRecords(Resource):
     def options(self):
         return {}
 
+    @assembly_ns.response(200, 'AssemblyDelta JSON', delta_fields)
     def post(self):
         """Add project records and assemble them.
 

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -125,6 +125,30 @@ sofia_json_model = api.model(
      'grounding_mode': fields.String(example='flat', required=False)  
     })
 
+# Models for response
+project_resp_model = api.model('ProjectResponse', {
+    'id': fields.String(example='project1', description='Project ID'),
+    'name': fields.String(example='Project 1', description='Project name')
+})
+
+project_records_resp = fields.List(fields.String, example=['record1, record2'])
+
+curated_mapping = fields.Raw(
+    example={'12345': '23456'},
+    description=(
+        'Mapping from old statement hashes to new statement hashes '
+        'if they changed due to the curations'))
+
+project_curation = fields.Wildcard(fields.Nested(curation_model), example={
+    '12345': {
+        'project_id': 'project1',
+        'statement_id': '83f5aec2-978b-4e01-a2c9-e231f90bfabd',
+        'update_type': 'discard_statement'
+    },
+}, description='Mapping from statement hashes to curations'
+)
+
+
 def _stmts_from_proc(proc):
     if proc and proc.statements:
         stmts = stmts_to_json(proc.statements)
@@ -255,6 +279,8 @@ class GetProjects(Resource):
     def options(self):
         return {}
 
+    @assembly_ns.marshal_list_with(project_resp_model,
+                                   description='List of projects')
     def get(self):
         """Get a list of all projects."""
         projects = sc.get_projects()
@@ -268,6 +294,7 @@ class GetProjectRecords(Resource):
     def options(self):
         return {}
 
+    # @assembly_ns.marshal_with(project_records_resp)
     def get(self):
         """Get records for a project.
 
@@ -293,6 +320,7 @@ class SubmitCurations(Resource):
     def options(self):
         return {}
 
+    # @assembly_ns.marshal_with(curated_mapping)
     def post(self):
         """Submit curations.
 
@@ -330,6 +358,7 @@ class GetProjectCurations(Resource):
     def options(self):
         return {}
 
+    # @assembly_ns.marshal_list_with(project_curation)
     def get(self):
         """Get project curations.
 

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -150,6 +150,20 @@ project_curation = fields.Wildcard(fields.Nested(curation_model), example={
     },
 })
 
+stmt_fields = fields.Raw(example={
+    "id": "acc6d47c-f622-41a4-8ae9-d7b0f3d24a2f",
+    "type": "Complex",
+    "members": [
+        {"db_refs": {"TEXT": "MEK", "FPLX": "MEK"}, "name": "MEK"},
+        {"db_refs": {"TEXT": "ERK", "FPLX": "ERK"}, "name": "ERK"}
+    ],
+    "sbo": "https://identifiers.org/SBO:0000526",
+    "evidence": [{"text": "MEK binds ERK", "source_api": "trips"}]
+})
+
+stmts_model = api.model('Statements', {
+    'statements': fields.List(stmt_fields)
+})
 
 def _stmts_from_proc(proc):
     if proc and proc.statements:
@@ -393,6 +407,7 @@ class HumeProcessJsonld(Resource):
     def options(self):
         return {}
 
+    @sources_ns.response(200, 'INDRA Statements', stmts_model)
     def post(self):
         """Process Hume JSON-LD and return INDRA Statements.
 
@@ -421,6 +436,7 @@ class CwmsProcessText(Resource):
     def options(self):
         return {}
 
+    @sources_ns.response(200, 'INDRA Statements', stmts_model)
     def post(self):
         """Process text with CWMS and return INDRA Statements.
 
@@ -448,6 +464,7 @@ class EidosProcessText(Resource):
     def options(self):
         return {}
 
+    @sources_ns.response(200, 'INDRA Statements', stmts_model)
     def post(self):
         """Process text with EIDOS and return INDRA Statements.
 
@@ -503,6 +520,7 @@ class EidosProcessJsonld(Resource):
     def options(self):
         return {}
 
+    @sources_ns.response(200, 'INDRA Statements', stmts_model)
     def post(self):
         """Process an EIDOS JSON-LD and return INDRA Statements.
 
@@ -551,6 +569,7 @@ class SofiaProcessJson(Resource):
     def options(self):
         return {}
 
+    @sources_ns.response(200, 'INDRA Statements', stmts_model)
     def post(self):
         """Process a Sofia JSON and return INDRA Statements.
 

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -19,6 +19,7 @@ sc = ServiceController(db_url, dart_client=dart_client)
 
 
 app = Flask(__name__)
+app.config['RESTX_MASK_SWAGGER'] = False
 api = Api(app, title='INDRA World Modelers API',
           description='REST API for INDRA World Modelers')
 

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -152,13 +152,10 @@ project_curation = fields.Wildcard(fields.Nested(curation_model), example={
 
 stmt_fields = fields.Raw(example={
     "id": "acc6d47c-f622-41a4-8ae9-d7b0f3d24a2f",
-    "type": "Complex",
-    "members": [
-        {"db_refs": {"TEXT": "MEK", "FPLX": "MEK"}, "name": "MEK"},
-        {"db_refs": {"TEXT": "ERK", "FPLX": "ERK"}, "name": "ERK"}
-    ],
-    "sbo": "https://identifiers.org/SBO:0000526",
-    "evidence": [{"text": "MEK binds ERK", "source_api": "trips"}]
+    "type": "Influence",
+    "subj": {"db_refs": {"WM": "wm/concept/causal_factor/environmental/meteorologic/precipitation/rainfall"}, "name": "rainfall"},
+    "obj": {"db_refs": {"WM": "wm/concept/causal_factor/crisis_and_disaster/environmental_disasters/natural_disaster/flooding"}, "name": "flood"},
+    "evidence": [{"text": "Rainfall causes flood", "source_api": "eidos"}]
 }, description='INDRA Statement JSON')
 
 stmts_model = api.model('Statements', {
@@ -169,17 +166,14 @@ delta_fields = fields.Raw(example={
     'new_statements': {
         '12345': {
             "id": "acc6d47c-f622-41a4-8ae9-d7b0f3d24a2f",
-            "type": "Complex",
-            "members": [
-                {"db_refs": {"TEXT": "MEK", "FPLX": "MEK"}, "name": "MEK"},
-                {"db_refs": {"TEXT": "ERK", "FPLX": "ERK"}, "name": "ERK"}
-            ],
-            "sbo": "https://identifiers.org/SBO:0000526",
-            "evidence": [{"text": "MEK binds ERK", "source_api": "trips"}]
-        }
+            "type": "Influence",
+            "subj": {"db_refs": {"WM": "wm/concept/causal_factor/environmental/meteorologic/precipitation/rainfall"}, "name": "rainfall"},
+            "obj": {"db_refs": {"WM": "wm/concept/causal_factor/crisis_and_disaster/environmental_disasters/natural_disaster/flooding"}, "name": "flood"},
+            "evidence": [{"text": "Rainfall causes flood", "source_api": "eidos"}]
+            }
     },
     'new_evidence': {
-        '12345': [{"text": "MEK binds ERK", "source_api": "trips"}]
+        '12345': [{"text": "Rainfall causes flood", "source_api": "eidos"}]
     },
     'new_refinements': [['12345', '23456'], ['34567', '45678']],
     'beliefs': {'12345': 0.7, '23456': 0.9}

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -131,13 +131,10 @@ project_resp_model = api.model('ProjectResponse', {
     'name': fields.String(example='Project 1', description='Project name')
 })
 
-project_records_resp = fields.List(fields.String, example=['record1, record2'])
+project_records_resp = fields.List(
+    fields.String, example=['bcd04c45-3cfc-456f-a31e-59e875aefabf.json'])
 
-curated_mapping = fields.Raw(
-    example={'12345': '23456'},
-    description=(
-        'Mapping from old statement hashes to new statement hashes '
-        'if they changed due to the curations'))
+curated_mapping = fields.Raw(example={'12345': '23456'})
 
 project_curation = fields.Wildcard(fields.Nested(curation_model), example={
     '12345': {
@@ -145,8 +142,7 @@ project_curation = fields.Wildcard(fields.Nested(curation_model), example={
         'statement_id': '83f5aec2-978b-4e01-a2c9-e231f90bfabd',
         'update_type': 'discard_statement'
     },
-}, description='Mapping from statement hashes to curations'
-)
+})
 
 
 def _stmts_from_proc(proc):
@@ -294,7 +290,7 @@ class GetProjectRecords(Resource):
     def options(self):
         return {}
 
-    # @assembly_ns.marshal_with(project_records_resp)
+    @assembly_ns.response(200, 'A list of records', project_records_resp)
     def get(self):
         """Get records for a project.
 
@@ -320,7 +316,9 @@ class SubmitCurations(Resource):
     def options(self):
         return {}
 
-    # @assembly_ns.marshal_with(curated_mapping)
+    @assembly_ns.response(200, description=(
+        'Mapping from old statement hashes to new statement hashes '
+        'if they changed due to the curations'), model=curated_mapping)
     def post(self):
         """Submit curations.
 
@@ -358,7 +356,8 @@ class GetProjectCurations(Resource):
     def options(self):
         return {}
 
-    # @assembly_ns.marshal_list_with(project_curation)
+    @assembly_ns.response(200, 'Mapping from statement hashes to curations',
+                          project_curation)
     def get(self):
         """Get project curations.
 

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -67,7 +67,7 @@ project_records_model = api.model(
                                  description='ID of a project'),
      'records': fields.List(
         fields.Nested(dart_record_model),
-        description='A list of records to add, each should have a storage_key')
+        description='A list of records to add')
      }
 )
 
@@ -80,7 +80,8 @@ curation_model = api.model(
             example='83f5aec2-978b-4e01-a2c9-e231f90bfabd',
             description='INDRA Statement ID'),
         'update_type': fields.String(example='discard_statement',
-                                     description='What to do with the Statement')
+                                     description='The curation operation '
+                                                 'applied to the Statement')
     }
 )
 
@@ -125,7 +126,7 @@ eidos_text_model = api.inherit('EidosText', wm_text_model, {
         fields.String, example=['WM'], required=False,
         description='A list of name spaces for which INDRA should represent groundings'),
     'extract_filter': fields.List(
-        fields.String, example=['Influence'], required=False,
+        fields.String, example=['influence'], required=False,
         description='A list of relation types to extract'),
     'grounding_mode': fields.String(example='flat', required=False)
 })
@@ -133,19 +134,20 @@ eidos_text_model = api.inherit('EidosText', wm_text_model, {
 eidos_jsonld_model = api.inherit('EidosJson', jsonld_model, {
     'grounding_ns': fields.List(
         fields.String, example=['WM'], required=False,
-        description='A list of name spaces for which INDRA should represent groundings'),
+        description='A list of name spaces for which INDRA should '
+                    'represent groundings'),
     'extract_filter': fields.List(
-        fields.String, example=['Influence'], required=False,
+        fields.String, example=['influence'], required=False,
         description='A list of relation types to extract'),
     'grounding_mode': fields.String(example='flat', required=False,
-                                    description='flat or compositional')    
+                                    description='flat or compositional')
 })
 
 sofia_json_model = api.model(
     'json',
     {'json': fields.String(example='{}', description='JSON reader output'),
      'extract_filter': fields.List(
-         fields.String(example=['Influence']), required=False,
+         fields.String(example=['influence']), required=False,
          description='A list of relation types to extract'),
      'grounding_mode': fields.String(example='flat', required=False,
                                      description='flat or compositional')  
@@ -203,6 +205,7 @@ delta_fields = fields.Raw(example={
     'new_refinements': [['12345', '23456'], ['34567', '45678']],
     'beliefs': {'12345': 0.7, '23456': 0.9}
 })
+
 
 def _stmts_from_proc(proc):
     if proc and proc.statements:

--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -43,33 +43,44 @@ dict_model = api.model('dict', {})
 
 dart_record_model = api.model(
     'DartRecord',
-    {'identity': fields.String(example='eidos'),
-     'version': fields.String(example='1.0'),
+    {'identity': fields.String(example='eidos',
+                               description='Name of the reader'),
+     'version': fields.String(example='1.0', description='Reader version'),
      'document_id': fields.String(
-         example='70a62e43-f881-47b1-8367-a3cca9450c03'),
+         example='70a62e43-f881-47b1-8367-a3cca9450c03',
+         description='ID of a document to process'),
      'storage_key': fields.String(
-         example='bcd04c45-3cfc-456f-a31e-59e875aefabf.json')
+         example='bcd04c45-3cfc-456f-a31e-59e875aefabf.json',
+         description='Key to store the record with')
     }
 )
 
 project_model = api.model(
     'Project',
-    {'project_id': fields.String(example='project1', required=True)}
+    {'project_id': fields.String(example='project1', required=True,
+                                 description='ID of a project')}
 )
 
 project_records_model = api.model(
     'ProjectRecords',
-    {'project_id': fields.String(example='project1'),
-     'records': fields.List(fields.Nested(dart_record_model))
+    {'project_id': fields.String(example='project1',
+                                 description='ID of a project'),
+     'records': fields.List(
+        fields.Nested(dart_record_model),
+        description='A list of records to add, each should have a storage_key')
      }
 )
 
 curation_model = api.model(
     'Curation',
     {
-        'project_id': fields.String(example='project1'),
-        'statement_id': fields.String(example='83f5aec2-978b-4e01-a2c9-e231f90bfabd'),
-        'update_type': fields.String(example='discard_statement')
+        'project_id': fields.String(example='project1',
+                                    description='ID of a project'),
+        'statement_id': fields.String(
+            example='83f5aec2-978b-4e01-a2c9-e231f90bfabd',
+            description='INDRA Statement ID'),
+        'update_type': fields.String(example='discard_statement',
+                                     description='What to do with the Statement')
     }
 )
 
@@ -82,48 +93,62 @@ curation_model_wrapped = api.model(
 
 submit_curations_model = api.model(
     'SubmitCurations',
-    {'project_id': fields.String(example='project1'),
+    {'project_id': fields.String(example='project1',
+                                 description='ID of a project'),
      'curations': fields.Nested(curation_model_wrapped)
      }
 )
 
 new_project_model = api.model(
     'NewProject',
-    {'project_id': fields.String(example='project1', required=True),
-     'project_name': fields.String(example='Project 1', required=True),
-     'corpus_id': fields.String(example='corpus1', required=False)
+    {'project_id': fields.String(example='project1', required=True,
+                                 description='ID of a project'),
+     'project_name': fields.String(example='Project 1', required=True,
+                                   description='Name of a project'),
+     'corpus_id': fields.String(example='corpus1', required=False,
+                                description='ID of a corpus')
      }
 )
 
 wm_text_model = api.model(
     'WMText',
-    {'text': fields.String(example='Rainfall causes floods.')})
+    {'text': fields.String(example='Rainfall causes floods.',
+                           description='Text to process')})
 
 jsonld_model = api.model(
     'jsonld',
-    {'jsonld': fields.String(example='{}')})
+    {'jsonld': fields.String(example='{}', description='JSON-LD reader output')})
 
 eidos_text_model = api.inherit('EidosText', wm_text_model, {
-    'webservice': fields.String,
-    'grounding_ns': fields.List(fields.String(example=['WM']), required=False),
-    'extract_filter': fields.List(fields.String(example=['Influence']),
-                                  required=False),
+    'webservice': fields.String(description='URL for Eidos webservice'),
+    'grounding_ns': fields.List(
+        fields.String, example=['WM'], required=False,
+        description='A list of name spaces for which INDRA should represent groundings'),
+    'extract_filter': fields.List(
+        fields.String, example=['Influence'], required=False,
+        description='A list of relation types to extract'),
     'grounding_mode': fields.String(example='flat', required=False)
 })
 
 eidos_jsonld_model = api.inherit('EidosJson', jsonld_model, {
-    'grounding_ns': fields.List(fields.String(example=['WM']), required=False),
-    'extract_filter': fields.List(fields.String(example=['Influence']),
-                                  required=False),
-    'grounding_mode': fields.String(example='flat', required=False)    
+    'grounding_ns': fields.List(
+        fields.String, example=['WM'], required=False,
+        description='A list of name spaces for which INDRA should represent groundings'),
+    'extract_filter': fields.List(
+        fields.String, example=['Influence'], required=False,
+        description='A list of relation types to extract'),
+    'grounding_mode': fields.String(example='flat', required=False,
+                                    description='flat or compositional')    
 })
 
 sofia_json_model = api.model(
     'json',
-    {'json': fields.String(example='{}'),
-     'extract_filter': fields.List(fields.String(example=['Influence']),
-                                   required=False),
-     'grounding_mode': fields.String(example='flat', required=False)  
+    {'json': fields.String(example='{}', description='JSON reader output'),
+     'extract_filter': fields.List(
+         fields.String(example=['Influence']), required=False,
+         description='A list of relation types to extract'),
+     'grounding_mode': fields.String(example='flat', required=False,
+                                     description='flat or compositional')  
     })
 
 # Models for response
@@ -528,7 +553,7 @@ class EidosProcessText(Resource):
         return _stmts_from_proc(ep)
 
 
-@sources_ns.expect(jsonld_model)
+@sources_ns.expect(eidos_jsonld_model)
 @sources_ns.route('/eidos/process_jsonld')
 class EidosProcessJsonld(Resource):
     @api.doc(False)


### PR DESCRIPTION
This PR extends WM REST API documentation by adding response models and descriptions to input models. All endpoints now have example response and brief description of an expected response. However due to a complex JSON structure of responses for multiple endpoints (e.g. Statement JSON, AssemblyDelta JSON) or dictionaries with dynamic keys (e.g. statement hash to curation mappings, etc.), some responses are defined as `fields` instead of `api.model` objects and passed to endpoints with `api.response` instead of `api.marshal_with`. This still allows displaying the example responses correctly, but does not document each field in the response (i.e. when clicking on `model` in the response object) and does not validate the responses. 