### PR TITLE
Improvements for corpus assembly and upload

### DIFF
--- a/indra_world/assembly/incremental_assembler.py
+++ b/indra_world/assembly/incremental_assembler.py
@@ -1,4 +1,5 @@
 import copy
+import tqdm
 import logging
 from copy import deepcopy
 import networkx
@@ -64,6 +65,7 @@ class IncrementalAssembler:
         self.known_corrects = set()
 
         if not refinement_filters:
+            logger.info('Initializing refinement filters')
             crf = CompositionalRefinementFilter(ontology=world_ontology)
             rcf = RefinementConfirmationFilter(ontology=world_ontology,
                 refinement_fun=location_refinement_compositional)
@@ -212,7 +214,8 @@ class IncrementalAssembler:
     def deduplicate(self):
         """Build hash-based statement and evidence data structures to
         deduplicate."""
-        for stmt in self.prepared_stmts:
+        logger.info('Deduplicating prepared statements')
+        for stmt in tqdm.tqdm(self.prepared_stmts):
             self.annotate_evidences(stmt)
             stmt_hash = stmt.get_hash(matches_fun=self.matches_fun)
             evs = stmt.evidence
@@ -230,9 +233,11 @@ class IncrementalAssembler:
     def get_refinements(self):
         """Calculate refinement relationships between de-duplicated statements.
         """
+        logger.info('Initializing refinement filters')
         for filter in self.refinement_filters:
             filter.initialize(self.stmts_by_hash)
-        for sh, stmt in self.stmts_by_hash.items():
+        logger.info('Applying refinement filters')
+        for sh, stmt in tqdm.tqdm(self.stmts_by_hash.items()):
             refinements = None
             for filter in self.refinement_filters:
                 # This gets less specific hashes
@@ -245,6 +250,7 @@ class IncrementalAssembler:
     def build_refinements_graph(stmts_by_hash, refinement_edges):
         """Return a refinements graph based on statements and refinement edges.
         """
+        logger.info('Building refinement graph')
         g = networkx.DiGraph()
         nodes = [(sh, {'stmt': stmt}) for sh, stmt in stmts_by_hash.items()]
         g.add_nodes_from(nodes)

--- a/indra_world/assembly/incremental_assembler.py
+++ b/indra_world/assembly/incremental_assembler.py
@@ -65,7 +65,7 @@ class IncrementalAssembler:
         self.known_corrects = set()
 
         if not refinement_filters:
-            logger.info('Initializing refinement filters')
+            logger.info('Instantiating refinement filters')
             crf = CompositionalRefinementFilter(ontology=world_ontology)
             rcf = RefinementConfirmationFilter(ontology=world_ontology,
                 refinement_fun=location_refinement_compositional)

--- a/indra_world/service/corpus_manager.py
+++ b/indra_world/service/corpus_manager.py
@@ -52,10 +52,7 @@ class CorpusManager:
         """
         all_stmts = []
         for record in self.dart_records:
-            stmts = self.sc.db.get_statements_for_document(
-                document_id=record['document_id'],
-                reader=record['reader'],
-                reader_version=record['reader_version'])
+            stmts = self.sc.db.get_statements_for_record(record['storage_key'])
             all_stmts += stmts
         ia = IncrementalAssembler(all_stmts)
         self.assembled_stmts = ia.get_statements()

--- a/indra_world/service/corpus_manager.py
+++ b/indra_world/service/corpus_manager.py
@@ -3,6 +3,7 @@
 for loading into CauseMos."""
 import os
 import json
+import tqdm
 import logging
 import datetime
 from indra.statements import stmts_to_json, stmts_to_json_file
@@ -25,7 +26,7 @@ class CorpusManager:
         self.metadata = metadata
         self.assembled_stmts = None
 
-    def prepare(self):
+    def prepare(self, records_exist=False):
         """Run the preprocessing pipeline on statements.
 
         This function adds the new corpus to the DB, adds records to the
@@ -33,16 +34,20 @@ class CorpusManager:
         statements, preprocesses the statements, and then stores these
         prepared statements in the DB.
         """
+        logger.info('Adding corpus %s to DB' % self.corpus_id)
         self.sc.db.add_corpus(self.corpus_id, self.metadata)
+        logger.info('Adding %d records for corpus' % len(self.dart_records))
         self.sc.db.add_records_for_corpus(
             self.corpus_id,
             [c['storage_key'] for c in self.dart_records]
         )
-        for record in self.dart_records:
-            # This adds DART records
-            self.sc.add_dart_record(record)
-            # This adds prepared statements
-            self.sc.process_dart_record(record)
+        if not records_exist:
+            logger.info('Adding and processing records')
+            for record in tqdm.tqdm(self.dart_records):
+                # This adds DART records
+                self.sc.add_dart_record(record)
+                # This adds prepared statements
+                self.sc.process_dart_record(record)
 
     def assemble(self):
         """Run assembly on the prepared statements.
@@ -51,11 +56,17 @@ class CorpusManager:
         corpus and then runs assembly on them.
         """
         all_stmts = []
-        for record in self.dart_records:
+        logger.info('Loading statements from DB for %d records' %
+                    len(self.dart_records))
+        for record in tqdm.tqdm(self.dart_records):
             stmts = self.sc.db.get_statements_for_record(record['storage_key'])
             all_stmts += stmts
+        logger.info('Instantiating incremental assembler with %d statements'
+                    % len(all_stmts))
         ia = IncrementalAssembler(all_stmts)
+        logger.info('Getting assembled statements')
         self.assembled_stmts = ia.get_statements()
+        logger.info('Got %d assembled statements' % len(self.assembled_stmts))
         self.metadata['num_statements'] = len(self.assembled_stmts)
 
     def dump_local(self, base_folder):

--- a/indra_world/service/corpus_manager.py
+++ b/indra_world/service/corpus_manager.py
@@ -86,16 +86,16 @@ class CorpusManager:
 
         # Upload statements
         jsonl_str = stmts_to_jsonl_str(self.assembled_stmts)
-        key = os.path.join(default_key_base, 'statements.json')
+        key = os.path.join(default_key_base, self.corpus_id, 'statements.json')
         s3.put_object(Body=jsonl_str, Bucket=default_bucket, Key=key)
 
         # Upload meta data
         metadata_str = json.dumps(self.metadata, indent=1)
-        key = os.path.join(default_key_base, 'metadata.json')
+        key = os.path.join(default_key_base, self.corpus_id, 'metadata.json')
         s3.put_object(Body=metadata_str, Bucket=default_bucket, Key=key)
 
         # Update index
-        key = os.path.join(default_key_base, 'index.csv')
+        key = os.path.join(default_key_base, self.corpus_id, 'index.csv')
         obj = s3.get_object(Bucket=default_bucket, Key=key)
         index_str = obj['Body'].read().decode('utf-8')
         if not index_str.endswith('\n'):

--- a/indra_world/service/db/manager.py
+++ b/indra_world/service/db/manager.py
@@ -29,6 +29,8 @@ class DbManager:
     def create_all(self):
         """Create all the database tables in the schema."""
         wms_schema.Base.metadata.create_all(self.engine)
+        self.engine.execute('create index record_key_idx on '
+                            'prepared_statements (record_key)')
 
     def query(self, *query_args):
         """Run and return results of a generic query."""
@@ -40,7 +42,8 @@ class DbManager:
         return self.engine.execute(query_str)
 
     def execute(self, operation):
-        """Execute an operation on the current session and return results."""
+        """Execute an insert operation on the current session and return
+        results."""
         session = self.get_session()
         try:
             res = session.execute(operation)


### PR DESCRIPTION
This PR makes several fixes and improvements related to assembling a "seed" corpus and adding it to the service and the associated DB. In addition to adding lots of logging, the changes are:
- Handling the case where the DART records already exist in the DB and don't need to be re-added
- Fetching statements by record instead of by paper, thereby avoiding issues related to redundant reader output records for a given document.
- Adding an index on storage keys for the prepared statements table to speed up retrieval
- Fix S3 key/path for corpus upload