### PR TITLE
Optimize set operations for refinement finding

### DIFF
--- a/indra_world/assembly/refinement.py
+++ b/indra_world/assembly/refinement.py
@@ -187,13 +187,12 @@ def get_relevants_for_stmt(sh, all_keys_by_role, agent_key_to_hash,
                     direction=direction)
                 # We now get the actual statement hashes that these other
                 # potentially refined agent keys appear in in the given role
-                role_relevant_stmt_hashes = set.union(
-                    *[agent_key_to_hash[role][comp_idx][rel]
-                      for rel in relevant_keys]) - {sh}
                 # In the first iteration, we initialize the set with the
                 # relevant statement hashes
                 if relevants is None:
-                    relevants = role_relevant_stmt_hashes
+                    relevants = set.union(
+                        *[agent_key_to_hash[role][comp_idx][rel]
+                          for rel in relevant_keys]) - {sh}
                 # If not none but an empty set then we can stop
                 # here
                 elif not relevants:
@@ -201,7 +200,11 @@ def get_relevants_for_stmt(sh, all_keys_by_role, agent_key_to_hash,
                 # In subsequent iterations, we take the intersection of
                 # the relevant sets per role
                 else:
-                    relevants &= role_relevant_stmt_hashes
+                    role_relevant_stmt_hashes = set()
+                    for rel in relevant_keys:
+                        role_relevant_stmt_hashes |= \
+                            (agent_key_to_hash[role][comp_idx][rel] & relevants)
+                    relevants = role_relevant_stmt_hashes - {sh}
     return relevants
 
 

--- a/indra_world/assembly/refinement.py
+++ b/indra_world/assembly/refinement.py
@@ -185,11 +185,11 @@ def get_relevants_for_stmt(sh, all_keys_by_role, agent_key_to_hash,
                     all_keys_by_role[role][comp_idx],
                     ontology=ontology,
                     direction=direction)
-                # We now get the actual statement hashes that these other
-                # potentially refined agent keys appear in in the given role
                 # In the first iteration, we initialize the set with the
                 # relevant statement hashes
                 if relevants is None:
+                    # Here we have to take a full union of potentially refined
+                    # hashes (removing the statement itself).
                     relevants = set.union(
                         *[agent_key_to_hash[role][comp_idx][rel]
                           for rel in relevant_keys]) - {sh}
@@ -200,10 +200,19 @@ def get_relevants_for_stmt(sh, all_keys_by_role, agent_key_to_hash,
                 # In subsequent iterations, we take the intersection of
                 # the relevant sets per role
                 else:
+                    # We start with an empty set and add to it any potentially
+                    # refined hashes
                     role_relevant_stmt_hashes = set()
                     for rel in relevant_keys:
+                        # We take the intersection of potentially refined
+                        # statements with ones we already know are relevant,
+                        # and add it to the union
                         role_relevant_stmt_hashes |= \
                             (agent_key_to_hash[role][comp_idx][rel] & relevants)
+                    # Since we already took all the intersections with relevants
+                    # in the loop, we can just set relevants to
+                    # role_relevant_stmt_hashes and remove the statement
+                    # itself
                     relevants = role_relevant_stmt_hashes - {sh}
     return relevants
 


### PR DESCRIPTION
This PR improves the implementation of set operations when finding potentially refined statements for a given statement. It changes a large union operation followed by an intersection to instead iterate through multiple smaller unions of intersections. For compositional grounding, this makes a big difference, and speeds up refinement finding by about **60x** (i.e., roughly reduces an hour to a minute).