### PR TITLE
Extend DART record schema

### DIFF
--- a/indra_world/service/app.py
+++ b/indra_world/service/app.py
@@ -254,9 +254,25 @@ class Notify(Resource):
 
         storage_key : str
             Key to store the record with.
+
+        output_version : str
+            The output version (typically ontology version).
+
+        labels : list of str
+            A list of labels for the output.
+
+        tenants : list of str
+            A list of tenants for the output.
         """
+        # We take these parameters as is
         record = {k: request.json[k] for k in ['identity', 'version',
-                                               'document_id', 'storage_key']}
+                                               'document_id', 'storage_key',
+                                               'output_version']}
+        # Here we stringify any lists
+        for key in ['labels', 'tenants']:
+            record[key] = None if key not in request.json \
+                else '|'.join(request.json[key])
+
         logger.info('Got notification for DART record: %s' % str(record))
         res = sc.add_dart_record(record)
         if res is None:

--- a/indra_world/service/controller.py
+++ b/indra_world/service/controller.py
@@ -64,9 +64,13 @@ class ServiceController:
             date = datetime.datetime.utcnow().isoformat()
         return self.db.add_dart_record(reader=record['identity'],
                                        reader_version=record['version'],
+                                       output_version=record['output_version'],
                                        document_id=record['document_id'],
                                        storage_key=record['storage_key'],
-                                       date=date)
+                                       date=date,
+                                       labels=record.get('labels'),
+                                       tenants=record.get('tenants'),
+                                       )
 
     def process_dart_record(self, record, grounding_mode='compositional',
                             extract_filter='influence'):

--- a/indra_world/service/db/manager.py
+++ b/indra_world/service/db/manager.py
@@ -206,27 +206,44 @@ class DbManager:
         return curations
 
     def add_dart_record(self, reader, reader_version, document_id, storage_key,
-                        date):
+                        date, output_version, labels):
         op = insert(wms_schema.DartRecords).values(
                 **{
                     'reader': reader,
                     'reader_version': reader_version,
                     'document_id': document_id,
                     'storage_key': storage_key,
-                    'date': date
+                    'date': date,
+                    'output_version': output_version,
+                    'labels': labels,
                 }
         )
         return self.execute(op)
 
-    def get_dart_records(self, reader, document_id, reader_version=None):
-        # TODO: allow more optional parameters
+    def get_dart_records(self, reader, document_id, reader_version=None,
+                         output_version=None, labels=None):
+        records = self.get_full_dart_records(reader, document_id,
+                                             reader_version, output_version,
+                                             labels)
+        return [r['storage_key'] for r in records]
+
+    def get_full_dart_records(self, reader, document_id, reader_version=None,
+                              output_version=None, labels=None):
         qfilter = wms_schema.DartRecords.document_id.like(document_id)
         qfilter = and_(qfilter, wms_schema.DartRecords.reader.like(reader))
         if reader_version:
             qfilter = and_(qfilter, wms_schema.DartRecords.
                            reader_version.like(reader_version))
-        q = self.query(wms_schema.DartRecords.storage_key).filter(qfilter)
-        keys = [r[0] for r in q.all()]
-        # TODO: should we just return the keys here or the full record?
-        # maybe add a different function for getting keys
-        return keys
+        if output_version:
+            qfilter = and_(qfilter, wms_schema.DartRecords.
+                           output_version.like(output_version))
+        q = self.query(wms_schema.DartRecords).filter(qfilter)
+        record_keys = ['reader', 'reader_version', 'document_id',
+                       'storage_key', 'date', 'output_version', 'labels']
+        records = [{k: r.__dict__.get(k) for k in record_keys} for r in q.all()]
+        # If some labels are given, we retain opnly records where there are
+        # some labels given and all the given labels are contained in those
+        if labels:
+            records = [r for r in records if r['labels'] and
+                       set(labels) <= set(r['labels'].split('|'))]
+        return records

--- a/indra_world/service/db/manager.py
+++ b/indra_world/service/db/manager.py
@@ -206,7 +206,7 @@ class DbManager:
         return curations
 
     def add_dart_record(self, reader, reader_version, document_id, storage_key,
-                        date, output_version=None, labels=None):
+                        date, output_version=None, labels=None, tenants=None):
         op = insert(wms_schema.DartRecords).values(
                 **{
                     'reader': reader,
@@ -216,19 +216,22 @@ class DbManager:
                     'date': date,
                     'output_version': output_version,
                     'labels': labels,
+                    'tenants': tenants
                 }
         )
         return self.execute(op)
 
     def get_dart_records(self, reader, document_id, reader_version=None,
-                         output_version=None, labels=None):
-        records = self.get_full_dart_records(reader, document_id,
-                                             reader_version, output_version,
-                                             labels)
+                         output_version=None, labels=None, tenants=None):
+        records = self.get_full_dart_records(
+            reader=reader, document_id=document_id,
+            reader_version=reader_version,
+            output_version=output_version,
+            labels=labels, tenants=tenants)
         return [r['storage_key'] for r in records]
 
     def get_full_dart_records(self, reader, document_id, reader_version=None,
-                              output_version=None, labels=None):
+                              output_version=None, labels=None, tenants=None):
         qfilter = wms_schema.DartRecords.document_id.like(document_id)
         qfilter = and_(qfilter, wms_schema.DartRecords.reader.like(reader))
         if reader_version:
@@ -238,12 +241,15 @@ class DbManager:
             qfilter = and_(qfilter, wms_schema.DartRecords.
                            output_version.like(output_version))
         q = self.query(wms_schema.DartRecords).filter(qfilter)
-        record_keys = ['reader', 'reader_version', 'document_id',
-                       'storage_key', 'date', 'output_version', 'labels']
+        record_keys = ['reader', 'reader_version', 'document_id', 'storage_key',
+                       'date', 'output_version', 'labels', 'tenants']
         records = [{k: r.__dict__.get(k) for k in record_keys} for r in q.all()]
         # If some labels are given, we retain opnly records where there are
         # some labels given and all the given labels are contained in those
         if labels:
             records = [r for r in records if r['labels'] and
                        set(labels) <= set(r['labels'].split('|'))]
+        if tenants:
+            records = [r for r in records if r['tenants'] and
+                       set(tenants) <= set(r['tenants'].split('|'))]
         return records

--- a/indra_world/service/db/manager.py
+++ b/indra_world/service/db/manager.py
@@ -206,7 +206,7 @@ class DbManager:
         return curations
 
     def add_dart_record(self, reader, reader_version, document_id, storage_key,
-                        date, output_version, labels):
+                        date, output_version=None, labels=None):
         op = insert(wms_schema.DartRecords).values(
                 **{
                     'reader': reader,

--- a/indra_world/service/db/schema.py
+++ b/indra_world/service/db/schema.py
@@ -50,7 +50,9 @@ class DartRecords(Base):
     document_id = Column(String)
     reader_version = Column(String)
     reader = Column(String)
+    output_version = Column(String)
     date = Column(String)
+    labels = Column(String)
 
 
 class Corpora(Base):

--- a/indra_world/service/db/schema.py
+++ b/indra_world/service/db/schema.py
@@ -53,6 +53,7 @@ class DartRecords(Base):
     output_version = Column(String)
     date = Column(String)
     labels = Column(String)
+    tenants = Column(String)
 
 
 class Corpora(Base):

--- a/indra_world/tests/test_db_manager.py
+++ b/indra_world/tests/test_db_manager.py
@@ -27,6 +27,33 @@ def test_dart_record():
     assert keys == ['xyz3']
 
 
+def test_dart_records_extended():
+    db = _get_db()
+    db.add_dart_record('eidos', '1.0', 'd1', 'stk1', '2021',
+                       '1.2', 'embed|test|xyz')
+    db.add_dart_record('eidos', '1.0', 'd1', 'stk2', '2021',
+                       '1.3', 'embed|test|abc')
+
+    keys = db.get_dart_records(reader='eidos', document_id='d1')
+    assert set(keys) == {'stk1', 'stk2'}
+
+    keys = db.get_dart_records(reader='eidos', document_id='d1',
+                               output_version='1.3')
+    assert set(keys) == {'stk2'}
+
+    keys = db.get_dart_records(reader='eidos', document_id='d1',
+                               labels={'abc'})
+    assert set(keys) == {'stk2'}
+
+    keys = db.get_dart_records(reader='eidos', document_id='d1',
+                               labels={'abc', 'xyz'})
+    assert set(keys) == set()
+
+    keys = db.get_dart_records(reader='eidos', document_id='d1',
+                               labels={'embed'})
+    assert set(keys) == {'stk1', 'stk2'}
+
+
 def test_statements():
     db = _get_db()
     db.add_dart_record('eidos', '1.0', 'abc1', 'xyz1', 'today')

--- a/indra_world/tests/test_db_manager.py
+++ b/indra_world/tests/test_db_manager.py
@@ -30,9 +30,9 @@ def test_dart_record():
 def test_dart_records_extended():
     db = _get_db()
     db.add_dart_record('eidos', '1.0', 'd1', 'stk1', '2021',
-                       '1.2', 'embed|test|xyz')
+                       '1.2', 'embed|test|xyz', 'tenant1')
     db.add_dart_record('eidos', '1.0', 'd1', 'stk2', '2021',
-                       '1.3', 'embed|test|abc')
+                       '1.3', 'embed|test|abc', 'tenant2|tenant3')
 
     keys = db.get_dart_records(reader='eidos', document_id='d1')
     assert set(keys) == {'stk1', 'stk2'}
@@ -52,6 +52,10 @@ def test_dart_records_extended():
     keys = db.get_dart_records(reader='eidos', document_id='d1',
                                labels={'embed'})
     assert set(keys) == {'stk1', 'stk2'}
+
+    keys = db.get_dart_records(reader='eidos', document_id='d1',
+                               tenants=['tenant3'])
+    assert set(keys) == {'stk2'}
 
 
 def test_statements():

--- a/indra_world/tests/test_rest_api.py
+++ b/indra_world/tests/test_rest_api.py
@@ -125,7 +125,8 @@ def test_get_project_records():
     record = {'identity': 'eidos',
               'version': '1.0',
               'document_id': doc_id,
-              'storage_key': storage_key}
+              'storage_key': storage_key,
+              'output_version': '1.2'}
     res = _call_api('post', 'dart/notify', json=record)
     res = _call_api('post', 'assembly/add_project_records',
                     json=dict(

--- a/indra_world/tests/test_rest_api.py
+++ b/indra_world/tests/test_rest_api.py
@@ -53,7 +53,10 @@ def test_notify():
                         identity='eidos',
                         version='1.0',
                         document_id=doc_id,
-                        storage_key=storage_key
+                        storage_key=storage_key,
+                        output_version='1.2',
+                        labels=['l1', 'l2'],
+                        tenants=['t1'],
                     ))
     assert res
     records = sc.db.get_dart_records(

--- a/indra_world/tests/test_service_controller.py
+++ b/indra_world/tests/test_service_controller.py
@@ -75,7 +75,8 @@ def test_add_reader_output():
     rec = {'identity': 'eidos',
            'version': '1.0',
            'document_id': 'd1',
-           'storage_key': 'xxx'}
+           'storage_key': 'xxx',
+           'output_version': '1.2'}
     sc.add_dart_record(rec, '2020')
     sc.add_project_records('p1', ['xxx'])
     eidos_output = _get_eidos_output()
@@ -94,14 +95,16 @@ def test_project():
         {'identity': 'eidos',
          'version': '1.0',
          'document_id': 'd1',
-         'storage_key': 'xxx'},
+         'storage_key': 'xxx',
+         'output_version': '1.2'},
         '2020'
     )
     sc.add_dart_record(
         {'identity': 'eidos',
          'version': '1.0',
          'document_id': 'd2',
-         'storage_key': 'yyy'},
+         'storage_key': 'yyy',
+         'output_version': '1.2'},
         '2020'
     )
     s1x = deepcopy(s1)
@@ -128,7 +131,8 @@ def test_duplicate_record():
     rec = {'identity': 'eidos',
            'version': '1.0',
            'document_id': 'd1',
-           'storage_key': 'xxx'}
+           'storage_key': 'xxx',
+           'output_version': '1.2'}
     res = sc.add_dart_record(rec, '2020')
     assert res.get('rowcount') == 1
     res = sc.add_dart_record(rec, '2020')

--- a/indra_world/tests/test_service_controller.py
+++ b/indra_world/tests/test_service_controller.py
@@ -46,11 +46,15 @@ def test_new_project_with_statements_load():
     rec1 = {'identity': 'eidos',
             'version': '1.0',
             'document_id': 'd1',
-            'storage_key': 'xxx'}
+            'storage_key': 'xxx',
+            'output_version': '1.2',
+            'tenants': 'a|b'}
     rec2 = {'identity': 'eidos',
             'version': '1.0',
             'document_id': 'd2',
-            'storage_key': 'yyy'}
+            'storage_key': 'yyy',
+            'output_version': '1.2',
+            'labels': 'x|y'}
     sc.add_dart_record(rec1)
     sc.add_dart_record(rec2)
     s1x = deepcopy(s1)


### PR DESCRIPTION
This PR extends the service DB schema with additional fields for DART records, namely `output_version`, `labels` and `tenants`. It also propagates handling these parameters into the service controller and the REST API itself.