### PR TITLE
Add no local storage DART option

### DIFF
--- a/indra_world/sources/dart/client.py
+++ b/indra_world/sources/dart/client.py
@@ -81,7 +81,7 @@ class DartClient:
                 raise ValueError('DART client initialized in local mode '
                                  'without a local storage path.')
         # If the local storage doesn't exist, we try create the folder
-        if not os.path.exists(self.local_storage):
+        if self.local_storage and (not os.path.exists(self.local_storage)):
             logger.info('The local storage path %s for the DART client '
                         'doesn\'t exist and will now be created' %
                         self.local_storage)
@@ -131,7 +131,7 @@ class DartClient:
         storage_key = record['storage_key']
         fname = self.get_local_storage_path(record)
         output = None
-        if os.path.exists(fname):
+        if fname and os.path.exists(fname):
             with open(fname, 'r') as fh:
                 output = fh.read()
         elif self.storage_mode == 'web':
@@ -173,6 +173,8 @@ class DartClient:
 
     def get_local_storage_path(self, record):
         """Return the local storage path for a DART record."""
+        if not self.local_storage:
+            return None
         folder = os.path.join(self.local_storage, record['identity'],
                               record['version'])
         if not os.path.exists(folder):

--- a/scripts/grounding_concept_of_process.py
+++ b/scripts/grounding_concept_of_process.py
@@ -1,0 +1,23 @@
+import csv
+from indra.statements import *
+stmts = stmts_from_json_file('august_embed_10k.json', format='jsonl')
+concepts = []
+for stmt in stmts:
+    for concept in stmt.agent_list():
+        concepts.append(concept)
+problems = []
+for concept in concepts:
+    if 'WM' in concept.db_refs:
+        gr = concept.db_refs['WM'][0]
+        if gr[0] and gr[2]:
+            if 'wm/process' in gr[0][0] and 'wm/concept' in gr[2][0]:
+                problems.append(concept)
+rows = [[problem.db_refs['TEXT'], problem.db_refs['WM'][0][0][0],
+         problem.db_refs['WM'][0][2][0]] for problem in problems
+        if not problem.db_refs['WM'][0][1] and not problem.db_refs['WM'][0][3]]
+rows = sorted(rows, key=lambda x: x[0])
+rows = [['text', 'theme', 'process']] + rows
+with open('grounding_concept_of_process.csv', 'w') as fh:
+    wr = csv.writer(fh, delimiter=',')
+    wr.writerows(rows)
+


### PR DESCRIPTION
This PR makes it possible to completely turn off local caching of reader outputs from DART.