### PR TITLE
Extend batch download and processing of reader outputs

### DIFF
--- a/indra_world/service/corpus_manager.py
+++ b/indra_world/service/corpus_manager.py
@@ -137,3 +137,11 @@ def get_corpus_index():
     index_str = obj['Body'].read().decode('utf-8')
     index_entries = [l.split(',') for l in index_str.split('\n') if l]
     return index_entries
+
+
+def download_corpus(corpus_id, fname):
+    s3 = _make_s3_client()
+    key = os.path.join(default_key_base, corpus_id, 'statements.json')
+    obj - s3.get_object(Bucket=default_bucket, Key=key)
+    with open(fname, 'w') as fh:
+        fh.write(obj['Body'].read().decode('utf-8'))

--- a/indra_world/service/corpus_manager.py
+++ b/indra_world/service/corpus_manager.py
@@ -139,7 +139,16 @@ def get_corpus_index():
     return index_entries
 
 
-def download_corpus(corpus_id, fname):
+def download_corpus(corpus_id: str, fname: str) -> None:
+    """Download a given corpus of assembled statements from S3.
+
+    Parameters
+    ----------
+    corpus_id :
+        The ID of the corpus.
+    fname :
+        The file in which the downloaded corpus should be written.
+    """
     s3 = _make_s3_client()
     key = os.path.join(default_key_base, corpus_id, 'statements.json')
     obj - s3.get_object(Bucket=default_bucket, Key=key)

--- a/indra_world/service/corpus_manager.py
+++ b/indra_world/service/corpus_manager.py
@@ -127,3 +127,13 @@ def _make_s3_client(profile_name='wm'):
 
 def stmts_to_jsonl_str(stmts):
     return '\n'.join([json.dumps(stmt) for stmt in stmts_to_json(stmts)])
+
+
+def get_corpus_index():
+    """Return the corpus index as a list of tuples with corpus IDs and dates."""
+    s3 = _make_s3_client()
+    key = os.path.join(default_key_base, 'index.csv')
+    obj = s3.get_object(Bucket=default_bucket, Key=key)
+    index_str = obj['Body'].read().decode('utf-8')
+    index_entries = [l.split(',') for l in index_str.split('\n') if l]
+    return index_entries

--- a/indra_world/sources/__init__.py
+++ b/indra_world/sources/__init__.py
@@ -1,0 +1,59 @@
+import tqdm
+import pickle
+import logging
+import functools
+from multiprocessing import Pool
+from indra_world.sources import eidos, hume, sofia
+
+logger = logging.getLogger(__name__)
+
+
+def _reader_wrapper(fname, reader, dart_ids=None, **kwargs):
+    if reader == 'eidos':
+        pr = eidos.process_json_file(fname, **kwargs)
+        pr.doc.tree = None
+    elif reader == 'sofia':
+        pr = sofia.process_json_file(fname, **kwargs)
+    elif reader == 'hume':
+        pr = hume.process_jsonld_file(fname, **kwargs)
+    if dart_ids:
+        dart_id = dart_ids.get(fname)
+        for stmt in pr.statements:
+            for ev in stmt.evidence:
+                ev.text_refs['DART'] = dart_id
+    return pr.statements
+
+
+def process_reader_outputs(fnames, reader,
+                           dart_ids=None,
+                           extract_filter=None,
+                           grounding_mode='compositional',
+                           nproc=8,
+                           output_pkl=None):
+    if extract_filter is None:
+        extract_filter = ['influence']
+
+    pool = Pool(nproc)
+    chunk_size = 10
+    process_fun = functools.partial(_reader_wrapper,
+                                    reader=reader, dart_ids=dart_ids,
+                                    extract_filter=extract_filter,
+                                    grounding_mode=grounding_mode)
+
+    stmts = []
+    for res in tqdm.tqdm(pool.imap_unordered(process_fun, fnames,
+                                             chunksize=chunk_size),
+                         total=len(fnames)):
+        stmts += res
+
+    logger.debug('Closing pool...')
+    pool.close()
+    logger.debug('Joining pool...')
+    pool.join()
+    logger.info('Pool closed and joined.')
+
+    if output_pkl:
+        logger.info(f'Writing into {output_pkl}')
+        with open(output_pkl, 'wb') as fh:
+            pickle.dump(stmts, fh)
+    return stmts

--- a/indra_world/sources/__init__.py
+++ b/indra_world/sources/__init__.py
@@ -2,7 +2,9 @@ import tqdm
 import pickle
 import logging
 import functools
+from typing import List, Mapping, Optional
 from multiprocessing import Pool
+from indra.statements import Statement
 from indra_world.sources import eidos, hume, sofia
 
 logger = logging.getLogger(__name__)
@@ -24,12 +26,40 @@ def _reader_wrapper(fname, reader, dart_ids=None, **kwargs):
     return pr.statements
 
 
-def process_reader_outputs(fnames, reader,
-                           dart_ids=None,
-                           extract_filter=None,
-                           grounding_mode='compositional',
-                           nproc=8,
-                           output_pkl=None):
+def process_reader_outputs(fnames: List[str],
+                           reader: str,
+                           dart_ids: Mapping[str, str] = None,
+                           extract_filter: List[str] = None,
+                           grounding_mode: str = 'compositional',
+                           nproc: int = 8,
+                           output_pkl: str = None) -> List[Statement]:
+    """Process a set of reader outputs in parallel.
+
+    Parameters
+    ----------
+    fnames :
+        The list of file paths to the reader outputs to be processed.
+    reader :
+        The name of the reader which produced the outputs.
+    dart_ids :
+        A dict which maps each fname in the fnames list to a DART document ID.
+        These are then set in the evidences of statements exxtracted from
+        the output.
+    extract_filter :
+        What types of statements to extract.
+    grounding_mode :
+        The type of grounding mode to use for processing.
+    nproc :
+        The number of workers to use for parallelization.
+    output_pkl :
+        The path to an output pickle file in which to dump the statements
+        extracted from the outputs.
+
+    Returns
+    -------
+    :
+        The list of statements extracted from the outputs.
+    """
     if extract_filter is None:
         extract_filter = ['influence']
 


### PR DESCRIPTION
This PR adds some more functions to do large-scale reader output processing. The `process_reader_outputs` function allows processing a folder of outputs from a given reader in a parallelized way. It also adds functions to retrieve assembled statements from S3.