### PR TITLE
Improve dockerized deployment

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,11 +1,11 @@
-Dockerized INDRA World service
-==============================
+# Dockerized INDRA World service
+
 This folder contains files to run the INDRA World service through Docker
 containers. It also provides files to build them locally in case
 customizations are needed.
 
-Running the integrated service
-------------------------------
+## Running the integrated service
+
 A docker-compose file defines how the service image and DB image need to be
 run. The docker-compose file refers to two images ([indralab/indra_world](https://hub.docker.com/repository/docker/indralab/indra_world) and [indralab/indra_world_db](https://hub.docker.com/repository/docker/indralab/indra_world_db)), both available publicly
 on Dockerhub. This means that they are automatically pulled when running
@@ -39,24 +39,23 @@ POSTGRES_PASSWORD=<password for local postgres>
 PGDATA=/var/lib/postgresql/pgdata
 ```
 
-Building the Docker images locally
------------------------------------
+## Building the Docker images locally
 
 As described above, the two necessary Docker images are available on Dockerhub,
 therefore the following steps are only necessary if local changes to the
 images (beyond what can be controlled through environmental variables)
 are needed.
 
-Building the INDRA World service image
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+### Building the INDRA World service image
+
 To build the `indra_world` Docker image, run
 
 ```
 docker build --tag indra_world:latest .
 ```
 
-Initializing the INDRA World DB image
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+### Initializing the INDRA World DB image
+
 To create the `indra_world_db` Docker image from scratch, run
 
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,42 +1,31 @@
 Dockerized INDRA World service
 ==============================
-This folder contains files to build necessary Docker images and run them.
-The INDRA World service requires a postgres database and we assume here
-that that database is available as a separate local image called postgres:indra_world,
-though any other local or remote DB can be used as well.
-
-Building the INDRA World service image
---------------------------------------
-To build the Docker image, run
-
-```
-docker build --tag indra_world:latest .
-```
-
-Initializing the INDRA World DB image
--------------------------------------
-To create the `postgres:indra_world` Docker image from scratch, run
-
-```
-./initialize_db_image.sh
-```
+This folder contains files to run the INDRA World service through Docker
+containers. It also provides files to build them locally in case
+customizations are needed.
 
 Running the integrated service
 ------------------------------
 A docker-compose file defines how the service image and DB image need to be
-run. To launch the service, run
+run. The docker-compose file refers to two images (`indralab/indra_world`
+and `indralab/indra_world_db`), both available publicly
+on Dockerhub. This means that they are automatically pulled when running
+`docker-compose up` unless they are already available locally.
+
+To launch the service, run
 
 ```
 docker-compose up -d
 ```
 where the optional `-d` flag runs the containers in the background.
 
-There are two files that need to be defined containing environment
+There are two files that need to be created containing environment
 variables for each container with the following names and content:
 
 `indra_world.env`
 ```
-INDRA_WM_SERVICE_DB=postgres://postgres:<password for local postgres>@db:5432
+INDRA_WM_SERVICE_DB=postgresql://postgres:<password for local postgres>@db:5432
+DART_WM_URL=<DART URL>
 DART_WM_USERNAME=<DART username>
 DART_WM_PASSWORD=<DART password>
 AWS_ACCESS_KEY_ID=<AWS account key ID, necessary if assembled outputs need to be dumped to S3 for CauseMos>
@@ -51,3 +40,29 @@ POSTGRES_PASSWORD=<password for local postgres>
 PGDATA=/var/lib/postgresql/pgdata
 ```
 
+Building the Docker images locally
+-----------------------------------
+
+As described above, the two necessary Docker images are available on Dockerhub,
+therefore the following steps are only necessary if local changes to the
+images (beyond what can be controlled through environmental variables)
+are needed.
+
+Building the INDRA World service image
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To build the `indra_world` Docker image, run
+
+```
+docker build --tag indra_world:latest .
+```
+
+Initializing the INDRA World DB image
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To create the `indra_world_db` Docker image from scratch, run
+
+```
+./initialize_db_image.sh
+```
+
+Note that this requires Python dependencies needed to run
+INDRA World to be available in the local environment.

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,8 +7,7 @@ customizations are needed.
 Running the integrated service
 ------------------------------
 A docker-compose file defines how the service image and DB image need to be
-run. The docker-compose file refers to two images (`indralab/indra_world`
-and `indralab/indra_world_db`), both available publicly
+run. The docker-compose file refers to two images ([indralab/indra_world](https://hub.docker.com/repository/docker/indralab/indra_world) and [indralab/indra_world_db](https://hub.docker.com/repository/docker/indralab/indra_world_db)), both available publicly
 on Dockerhub. This means that they are automatically pulled when running
 `docker-compose up` unless they are already available locally.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.3"
 services:
   service:
-    image: indra_world
+    image: indralab/indra_world
     ports:
       - "8001:8000"
     env_file: indra_world.env
     entrypoint: gunicorn -w 1 -b :8000 -t 600 indra_world.service.app:app
   db:
-    image: postgres:indra_world
+    image: indralab/indra_world_db
     env_file: indra_world_db.env

--- a/docker/initialize_db_image.sh
+++ b/docker/initialize_db_image.sh
@@ -21,6 +21,6 @@ python -c "from indra_world.service.db import DbManager;
 db = DbManager('postgresql://postgres:$POSTGRES_PASSWORD@localhost:$TEMP_CONTAINER_PORT');
 db.create_all()"
 # We now commit the Docker image with the schema baked in
-docker commit $container_id postgres:indra_world
+docker commit $container_id indra_world_db:latest
 # We can finally stop the container
 docker stop $container_id

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     flask_wtf
     flask_bootstrap
     flask_restx < 0.4
+    gunicorn
     sqlalchemy
 
 include_package_data = True


### PR DESCRIPTION
This PR further streamlines deploying the INDRA World service. The two Docker images are now available on Dockerhub and `docker-compose.yml` as well as the the updated instructions refer to these instead of recommending building the images locally. The documentation is further improved to fix some issues with the environment variable templates. FYI @yanzv.