### PR TITLE
Add CLI for assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,51 @@ For more information, see https://github.com/indralab/indra_world/tree/master/do
 
 Detailed documentation is available at:
 https://indra-world.readthedocs.io/en/latest/.
+
+## Command line interface
+
+The INDRA World command line interface allows running assembly using externally
+supplied arguments and configurations files. This serves as an alternative
+to using the Python API.
+
+```
+usage: indra_world [-h]
+                   (--reader-output-files READER_OUTPUT_FILES | --reader-output-dart-query READER_OUTPUT_DART_QUERY | --reader-output-dart-keys READER_OUTPUT_DART_KEYS)
+                   [--assembly-config ASSEMBLY_CONFIG]
+                   (--ontology-path ONTOLOGY_PATH | --ontology-id ONTOLOGY_ID) --output-path OUTPUT_PATH
+                   [--causemos-metadata CAUSEMOS_METADATA]
+
+INDRA World assembly CLI
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+Input options:
+  --reader-output-files READER_OUTPUT_FILES
+                        Path to a JSON file whose keys are reading system identifiers and whose values are
+                        lists of file paths to outputs from the given system to be used in assembly.
+  --reader-output-dart-query READER_OUTPUT_DART_QUERY
+                        Path to a JSON file that specifies query parameters for reader output records in DART.
+                        Only applicable if DART is being used.
+  --reader-output-dart-keys READER_OUTPUT_DART_KEYS
+                        Path to a text file where each line is a DART storage key corresponding to a reader
+                        output record. Only applicable if DART is being used.
+
+Assembly options:
+  --assembly-config ASSEMBLY_CONFIG
+                        Path to a JSON file that specifies the INDRA assembly pipeline. If not provided, the
+                        default assembly pipeline will be used.
+  --ontology-path ONTOLOGY_PATH
+                        Path to an ontology YAML file.
+  --ontology-id ONTOLOGY_ID
+                        The identifier of an ontology registered in DART. Only applicable if DART is being
+                        used.
+
+Output options:
+  --output-path OUTPUT_PATH
+                        The path to a folder to which the INDRA output will be written.
+  --causemos-metadata CAUSEMOS_METADATA
+                        Path to a JSON file that provides metadata to be used for a Causemos-compatible dump
+                        of INDRA output (which consists of multiple files). THe --output-path option must also
+                        be used along with this option.
+```

--- a/indra_world/__main__.py
+++ b/indra_world/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == '__main__':
+    main()

--- a/indra_world/cli.py
+++ b/indra_world/cli.py
@@ -1,8 +1,10 @@
 import argparse
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="INDRA World assembly CLI")
+def main():
+    parser = argparse.ArgumentParser(
+        prog='indra_world',
+        description="INDRA World assembly CLI")
 
     group = parser.add_argument_group('Input options')
     gg = group.add_mutually_exclusive_group()

--- a/indra_world/cli.py
+++ b/indra_world/cli.py
@@ -2,11 +2,10 @@ import os
 import json
 import logging
 import argparse
-from collections import defaultdict
 from indra.pipeline import AssemblyPipeline
 from indra.statements import stmts_to_json_file
 from indra_world.assembly.incremental_assembler import IncrementalAssembler
-from indra_world.sources import dart, eidos, hume, sofia
+from indra_world.sources import dart
 from indra_world.ontology import WorldOntology
 from indra_world.assembly.operations import *
 from indra_world.service.controller import preparation_pipeline
@@ -138,3 +137,7 @@ def main():
     else:
         output_fname = os.path.join(args.output_path, 'statements.json')
     stmts_to_json_file(assembled_stmts, output_fname, format='jsonl')
+
+
+if __name__ == '__main__':
+    main()

--- a/indra_world/cli.py
+++ b/indra_world/cli.py
@@ -1,0 +1,54 @@
+import argparse
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="INDRA World assembly CLI")
+
+    group = parser.add_argument_group('Input options')
+    gg = group.add_mutually_exclusive_group()
+
+    gg.add_argument(
+        '--reader-output-files', type=str,
+        help="Path to a JSON file whose keys are reading system identifiers "
+             "and whose values are lists of file paths to outputs from "
+             "the given system to be used in assembly.")
+    gg.add_argument(
+        '--reader-output-dart-query', type=str,
+        help="Path to a JSON file that specifies query parameters for "
+             "reader output records in DART. Only applicable if DART is "
+             "being used.")
+    gg.add_argument(
+        '--reader-output-dart-keys', type=str,
+        help="Path to a text file where each line is a DART storage key "
+             "corresponding to a reader output record. Only applicable if "
+             "DART is being used.")
+
+    group = parser.add_argument_group('Assembly options')
+
+    group.add_argument(
+        '--assembly-config', type=str,
+        help="Path to a JSON file that specifies the INDRA assembly pipeline. "
+             "If not provided, the default assembly pipeline will be used.")
+
+    gg = group.add_mutually_exclusive_group()
+
+    gg.add_argument(
+        '--ontology-path', type=str, help="Path to an ontology YAML file.")
+    gg.add_argument(
+        '--ontology-id', type=str,
+        help="The identifier of an ontology "
+             "registered in DART. Only applicable if DART is being used.")
+
+    group = parser.add_argument_group('Output options')
+
+    group.add_argument(
+        '--output-path', type=str,
+        help="The path to a folder to which the INDRA output will be written.")
+    group.add_argument(
+        '--causemos-output-config', type=str,
+        help="Path to a JSON file that provides metadata to be used for a "
+             "Causemos-compatible dump of INDRA output (which consists of "
+             "multiple files). THe --output-path option must also be used "
+             "along with this option.")
+
+    args = parser.parse_args()

--- a/indra_world/cli.py
+++ b/indra_world/cli.py
@@ -1,4 +1,17 @@
+import json
 import argparse
+
+
+def load_json_file(fname):
+    with open(fname, 'r') as fh:
+        content = json.load(fh)
+    return content
+
+
+def load_list_file(fname):
+    with open(fname, 'r') as fh:
+        elements = fh.read().splitlines()
+    return elements
 
 
 def main():
@@ -7,7 +20,7 @@ def main():
         description="INDRA World assembly CLI")
 
     group = parser.add_argument_group('Input options')
-    gg = group.add_mutually_exclusive_group()
+    gg = group.add_mutually_exclusive_group(required=True)
 
     gg.add_argument(
         '--reader-output-files', type=str,
@@ -32,7 +45,7 @@ def main():
         help="Path to a JSON file that specifies the INDRA assembly pipeline. "
              "If not provided, the default assembly pipeline will be used.")
 
-    gg = group.add_mutually_exclusive_group()
+    gg = group.add_mutually_exclusive_group(required=True)
 
     gg.add_argument(
         '--ontology-path', type=str, help="Path to an ontology YAML file.")
@@ -44,7 +57,7 @@ def main():
     group = parser.add_argument_group('Output options')
 
     group.add_argument(
-        '--output-path', type=str,
+        '--output-path', type=str, required=True,
         help="The path to a folder to which the INDRA output will be written.")
     group.add_argument(
         '--causemos-output-config', type=str,
@@ -54,3 +67,14 @@ def main():
              "along with this option.")
 
     args = parser.parse_args()
+
+    if args.reader_output_files:
+        index = load_json_file(args.reader_output_files)
+        for reader, files in index.items():
+            pass
+    elif args.reader_output_dart_query:
+        query_args = load_json_file(args.reader_output_dart_query)
+        pass
+    elif args.reader_output_dart_keys:
+        record_keys = load_list_file(args.reader_output_dart_keys)
+        pass

--- a/indra_world/service/corpus_manager.py
+++ b/indra_world/service/corpus_manager.py
@@ -89,15 +89,17 @@ class CorpusManager:
         logger.info('Got %d assembled statements' % len(self.assembled_stmts))
         self.metadata['num_statements'] = len(self.assembled_stmts)
 
-    def dump_local(self, base_folder):
+    def dump_local(self, base_folder, causemos_compatible=True):
         """Dump assembled corpus into local files."""
-        corpus_folder = os.path.join(base_folder, self.corpus_id)
-        os.makedirs(corpus_folder, exist_ok=True)
-        stmts_to_json_file(self.assembled_stmts,
-                           os.path.join(corpus_folder, 'statements.json'),
-                           format='jsonl')
-        with open(os.path.join(corpus_folder, 'metadata.json'), 'w') as fh:
-            json.dump(fh, self.metadata)
+        if causemos_compatible:
+            corpus_folder = os.path.join(base_folder, self.corpus_id)
+            os.makedirs(corpus_folder, exist_ok=True)
+            with open(os.path.join(corpus_folder, 'metadata.json'), 'w') as fh:
+                json.dump(fh, self.metadata)
+            fname = os.path.join(corpus_folder, 'statements.json')
+        else:
+            fname = os.path.join(base_folder, 'statements.json')
+        stmts_to_json_file(self.assembled_stmts, fname, format='jsonl')
 
     def dump_s3(self):
         """Dump assembled corpus onto S3."""

--- a/indra_world/sources/dart/api.py
+++ b/indra_world/sources/dart/api.py
@@ -48,17 +48,19 @@ def process_reader_output(reader, reader_output_str, doc_id,
         return []
 
 
-def process_reader_outputs(outputs, corpus_id, grounding_mode='compositional',
+def process_reader_outputs(outputs, corpus_id=None,
+                           grounding_mode='compositional',
                            extract_filter=None):
     if not extract_filter:
         extract_filter = ['influence']
     all_stmts = []
     for reader, reader_outputs in outputs.items():
-        fname = '%s_%s_raw.pkl' % (corpus_id, reader)
-        if os.path.exists(fname):
-            with open(fname, 'rb') as fh:
-                all_stmts += pickle.load(fh)
-                continue
+        if corpus_id:
+            fname = '%s_%s_raw.pkl' % (corpus_id, reader)
+            if os.path.exists(fname):
+                with open(fname, 'rb') as fh:
+                    all_stmts += pickle.load(fh)
+                    continue
         logger.info('Processing %d outputs for %s' %
                     (len(reader_outputs), reader))
         reader_stmts = []
@@ -68,8 +70,9 @@ def process_reader_outputs(outputs, corpus_id, grounding_mode='compositional',
                                                   doc_id,
                                                   grounding_mode=grounding_mode,
                                                   extract_filter=extract_filter)
-        with open(fname, 'wb') as fh:
-            pickle.dump(reader_stmts, fh)
+        if corpus_id:
+            with open(fname, 'wb') as fh:
+                pickle.dump(reader_stmts, fh)
         all_stmts += reader_stmts
     assert all(isinstance(stmt, Statement) for stmt in all_stmts)
     return all_stmts


### PR DESCRIPTION
This PR adds a new CLI for running assembly on a set of reader outputs and dumping a set of assembled INDRA Statements.  Options include support for working with or without DART to access reader outputs and the ontology, and support for dumping outputs compatible with CauseMos.