### PR TITLE
Link projects back to the corpus it was derived from

### DIFF
--- a/indra_world/assembly/incremental_assembler.py
+++ b/indra_world/assembly/incremental_assembler.py
@@ -52,7 +52,7 @@ class IncrementalAssembler:
                  matches_fun=location_matches_compositional,
                  curations=None,
                  post_processing_steps=None,
-                 ontology=world_ontology):
+                 ontology=None):
         self.matches_fun = matches_fun
         # These are preassembly data structures
         self.stmts_by_hash = {}
@@ -60,7 +60,7 @@ class IncrementalAssembler:
         self.refinement_edges = set()
         self.prepared_stmts = prepared_stmts
         self.known_corrects = set()
-        self.ontology = ontology
+        self.ontology = ontology if ontology else world_ontology
 
         if not refinement_filters:
             logger.info('Instantiating refinement filters')

--- a/indra_world/service/controller.py
+++ b/indra_world/service/controller.py
@@ -48,8 +48,16 @@ class ServiceController:
             prepared_stmts += self.db.get_statements_for_record(record_key)
         # 3. Select curations for project
         curations = self.get_project_curations(project_id)
-        # 4. Initiate an assembler
-        assembler = IncrementalAssembler(prepared_stmts, curations=curations)
+        # 4. Try to find the right ontology
+        ontology = None
+        corpus_id = self.db.get_corpus_for_project(project_id)
+        if corpus_id:
+            tenant = self.db.get_tenant_for_corpus(corpus_id)
+            if tenant:
+                ontology = self.dart_client.get_tenant_ontology_graph(tenant)
+        # 5. Initiate an assembler
+        assembler = IncrementalAssembler(prepared_stmts, curations=curations,
+                                         ontology=ontology)
         self.assemblers[project_id] = assembler
 
     def unload_project(self, project_id):

--- a/indra_world/service/controller.py
+++ b/indra_world/service/controller.py
@@ -30,7 +30,7 @@ class ServiceController:
 
     def new_project(self, project_id, name, corpus_id=None):
         """Create a new blank project or one based on an existing corpus."""
-        res = self.db.add_project(project_id, name)
+        res = self.db.add_project(project_id, name, corpus_id=corpus_id)
         if res is None:
             return None
         if corpus_id:

--- a/indra_world/service/db/manager.py
+++ b/indra_world/service/db/manager.py
@@ -55,7 +55,7 @@ class DbManager:
             session.rollback()
             return None
 
-    def add_project(self, project_id, name):
+    def add_project(self, project_id, name, corpus_id=None):
         """Add a new project.
 
         Parameters
@@ -64,9 +64,13 @@ class DbManager:
             The project ID.
         name : str
             The project name
+        corpus_id : Optional[str]
+            The corpus ID from which the project was derived, if
+            available.
         """
         op = insert(wms_schema.Projects).values(id=project_id,
-                                                name=name)
+                                                name=name,
+                                                corpus_id=corpus_id)
         return self.execute(op)
 
     def add_records_for_project(self, project_id, record_keys):

--- a/indra_world/service/db/manager.py
+++ b/indra_world/service/db/manager.py
@@ -100,9 +100,31 @@ class DbManager:
         return doc_ids
 
     def get_projects(self):
+        """Retyurn a list of all projects."""
         q = self.query(wms_schema.Projects)
         projects = [{'id': p.id, 'name': p.name} for p in q.all()]
         return projects
+
+    def get_corpus_for_project(self, project_id):
+        """Return the corpus ID that a project was derived from, if available."""
+        q = self.query(wms_schema.Projects.corpus_id).filter(
+            wms_schema.Projects.id.like(project_id))
+        res = list(q.all())
+        if res:
+            return res[0][0]
+        else:
+            return None
+
+    def get_tenant_for_corpus(self, corpus_id):
+        """Return the tenant for a given corpus, if available."""
+        q = self.query(wms_schema.Corpora.meta_data).filter(
+            wms_schema.Corpora.id.like(corpus_id))
+        res = list(q.all())
+        if res:
+            metadata = res[0][0]
+            return metadata.get('tenant')
+        else:
+            return None
 
     def add_corpus(self, corpus_id, metadata):
         op = insert(wms_schema.Corpora).values(id=corpus_id,

--- a/indra_world/service/db/schema.py
+++ b/indra_world/service/db/schema.py
@@ -10,6 +10,7 @@ class Projects(Base):
     id = Column(String, primary_key=True)
     name = Column(String)
     ontology_id = Column(Integer)
+    corpus_id = Column(String)
 
 
 class ProjectRecords(Base):


### PR DESCRIPTION
This PR extends the service DB to keep track of the corpus from which a project was derived allowing to look up metadata associated with the corpus such as the tenant and the corresponding ontology.