### PR TITLE
Include READMEs in the documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,11 +32,12 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx_autodoc_typehints',
+    'm2r2',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
 master_doc = 'index'
 pygments_style = 'sphinx'
 numpydoc_show_class_members = False

--- a/doc/general.rst
+++ b/doc/general.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../README.md

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,8 +9,10 @@ INDRA World
 .. toctree::
    :maxdepth: 3
 
+   general.rst
    service.rst
    modules/index
+
 
 
 Indices and tables

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,3 +9,4 @@ sqlalchemy
 flask_wtf
 flask_bootstrap
 flask_restx
+m2r

--- a/doc/service.rst
+++ b/doc/service.rst
@@ -1,49 +1,22 @@
-World Modelers INDRA service stack
-==================================
+.. mdinclude:: ../docker/README.md
 
 .. _wm-service-endpoints:
 
-Using the INDRA World API
--------------------------
+Using the public INDRA World API
+--------------------------------
 The API is deployed and documented at `wm.indra.bio <http://wm.indra.bio/>`_.
-It can also be run locally via Docker through steps documented `here <https://github.com/indralab/indra_world/tree/master/docker#dockerized-indra-world-service>`_ and below.
-
-.. _wm-service-local-setup:
-
-Setting up the INDRA World API locally
---------------------------------------
-These instructions describe setting up and using the INDRA service stack
-for World Modelers applications.
-
-.. code-block:: sh
-
-    git clone https://github.com/indralab/indra_world.git
-    cd indra_world/docker
-
-Then, in the same folder, do:
-
-.. code-block:: sh
-
-    docker-compose up -d
-
-to run the INDRA World service as well as an associated postgres container
-with the relational database used by the service. The `docker-compose` file
-reads secret configuration values for accessing various resources from two
-files: `indra_world.env` and `indra_world_db.env`. These files are not part
-of the public code and need to be added manually. You can find more details
-`here <https://github.com/indralab/indra_world/tree/master/docker#dockerized-indra-world-service>`_.
 
 .. _wm-service-s3:
 
-INDRA assemblies on S3
-----------------------
+Cloud-based CauseMos integration via S3
+---------------------------------------
 Access to the INDRA-assembled corpora requires credentials to the shared
 World Modelers S3 bucket "world-modelers". Each INDRA-assembled corpus is
 available within this bucket, under the "indra_models" key base. Each corpus
 is identified by a string identifier.
 
 The corpus index
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 The list of corpora can be obtained either using S3's list objects function
 or by reading the index.csv file which is maintained by INDRA. This index
 is a comma separated values text file which contains one row for each corpus.
@@ -58,8 +31,10 @@ row in this file looks as follows
 where test1_newlines is the corpus identifier and 2020-05-08-22-34-29 is the
 upload date-time.
 
+.. _wm-service-corpus-structure:
+
 Structure of each corpus
-~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^
 Within the world-modelers bucket, under the indra_models key base, files
 for each corpus are organized under a subkey equivalent to the corpus
 identifier, for instance, all the files for the test1_newlines corpus


### PR DESCRIPTION
This PR extends the documentation with two READMEs that are part of the Github repo using the m2r2 package to make sure that the content of the READMEs is not duplicated redundantly.